### PR TITLE
Call super init and add '.model' attribute to DeferringRelatedManager

### DIFF
--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -26,7 +26,9 @@ def create_deferring_foreign_related_manager(related, original_manager_cls):
 
     class DeferringRelatedManager(models.Manager):
         def __init__(self, instance):
+            super(DeferringRelatedManager, self).__init__()
             self.instance = instance
+            self.model = instance.__class__
 
         def get_live_query_set(self):
             """


### PR DESCRIPTION
This fixes a Django 1.7 compatibility issue
