### PR TITLE
Update Travis badge URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://travis-ci.org/torchbox/django-modelcluster.png?branch=master
-    :target: https://travis-ci.org/torchbox/django-modelcluster
+.. image:: https://travis-ci.org/wagtail/django-modelcluster.png?branch=master
+    :target: https://travis-ci.org/wagtail/django-modelcluster
 
 django-modelcluster
 ===================


### PR DESCRIPTION
The old one was still pointing at torchbox/django-modelcluster, thus reporting status "unknown"