### PR TITLE
Add optional dependency using extras - fixes #67

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+~~~~~~~~~~
+* Added the ability to install the optional dependency `django-taggit`
+  using `pip install django-modelcluster[taggit]`
+
 3.0.1 (02.02.2017)
 ~~~~~~~~~~~~~~~~~~
 * Fix: Added _result_cache property on FakeQuerySet (necessary for model forms with ParentalManyToManyFields to work correctly on Django 1.8-1.9)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ setup(
     install_requires=[
         "pytz>=2015.2",
     ],
+    extras_require={
+         'taggit': ['django-taggit>=0.20'],
+    },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',


### PR DESCRIPTION
This package may now be installed with the optional dependency `django-taggit` using:

```pip install django-modelcluster[taggit]```