### PR TITLE
Fix TransientModelFormSet for Django 1.11

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,8 +1,9 @@
 Changelog
 =========
 
-Unreleased
-~~~~~~~~~~
+3.1 (xx.xx.xxxx)
+~~~~~~~~~~~~~~~~
+* Django 1.11 compatibility
 * Added the ability to install the optional dependency `django-taggit`
   using `pip install django-modelcluster[taggit]`
 

--- a/modelcluster/forms.py
+++ b/modelcluster/forms.py
@@ -1,12 +1,11 @@
 from __future__ import unicode_literals
 
+import django
 from django.utils.six import with_metaclass
-
 from django.forms.models import (
     BaseModelFormSet, modelformset_factory,
     ModelForm, _get_foreign_key, ModelFormMetaclass, ModelFormOptions
 )
-
 from django.db.models.fields.related import ForeignObjectRel
 
 
@@ -66,6 +65,16 @@ class BaseTransientModelFormSet(BaseModelFormSet):
                 if not commit:
                     self.saved_forms.append(form)
         return saved_instances
+
+    if django.VERSION < (1, 9):
+        def save_existing(self, form, instance, commit=True):
+            """Saves and returns an existing model instance for the given form."""
+            return form.save(commit=commit)
+
+        def delete_existing(self, obj, commit=True):
+            """Deletes an existing model instance."""
+            if commit:
+                obj.delete()
 
 
 def transientmodelformset_factory(model, formset=BaseTransientModelFormSet, **kwargs):


### PR DESCRIPTION
Fixes #66

We need to override _construct_form so that it doesn't skip over initial
forms whose instance has a blank PK (which is taken as an indication that
the form was constructed with an instance not present in our queryset).
This reverses the effect of the following Django patch:

https://code.djangoproject.com/ticket/27416
https://github.com/django/django/commit/181f492ad021aeb43105aa9d38106ad7baf00211