### PR TITLE
Add Django 2.0 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,12 @@ matrix:
      python: 3.5
    - env: TOXENV=py36-dj111-sqlite
      python: 3.6
+   - env: TOXENV=py34-dj20-sqlite
+     python: 3.4
+   - env: TOXENV=py35-dj20-sqlite
+     python: 3.5
+   - env: TOXENV=py36-dj20-sqlite
+     python: 3.6
    - env: TOXENV=py27-dj19-postgres
      python: 2.7
    - env: TOXENV=py34-dj19-postgres
@@ -36,6 +42,12 @@ matrix:
    - env: TOXENV=py35-dj111-postgres
      python: 3.5
    - env: TOXENV=py36-dj111-postgres
+     python: 3.6
+   - env: TOXENV=py34-dj20-postgres
+     python: 3.4
+   - env: TOXENV=py35-dj20-postgres
+     python: 3.5
+   - env: TOXENV=py36-dj20-postgres
      python: 3.6
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ sudo: false
 
 matrix:
   include:
-   - env: TOXENV=py27-dj18-sqlite
-     python: 2.7
-   - env: TOXENV=py33-dj18-sqlite
-     python: 3.3
-   - env: TOXENV=py34-dj18-sqlite
-     python: 3.4
    - env: TOXENV=py27-dj19-sqlite
      python: 2.7
    - env: TOXENV=py34-dj19-sqlite
@@ -27,12 +21,6 @@ matrix:
      python: 3.5
    - env: TOXENV=py36-dj111-sqlite
      python: 3.6
-   - env: TOXENV=py27-dj18-postgres
-     python: 2.7
-   - env: TOXENV=py33-dj18-postgres
-     python: 3.3
-   - env: TOXENV=py34-dj18-postgres
-     python: 3.4
    - env: TOXENV=py27-dj19-postgres
      python: 2.7
    - env: TOXENV=py34-dj19-postgres

--- a/modelcluster/contrib/taggit.py
+++ b/modelcluster/contrib/taggit.py
@@ -20,7 +20,7 @@ class _ClusterTaggableManager(_TaggableManager):
         DeferringRelatedManager which allows writing related objects without committing them
         to the database.
         """
-        rel_name = self.through._meta.get_field('content_object').rel.get_accessor_name()
+        rel_name = self.through._meta.get_field('content_object').remote_field.get_accessor_name()
         return getattr(self.instance, rel_name)
 
     def get_queryset(self, extra_filters=None):
@@ -95,5 +95,5 @@ class ClusterTaggableManager(TaggableManager):
         # retrieve the queryset via the related manager on the content object,
         # to accommodate the possibility of this having uncommitted changes relative to
         # the live database
-        rel_name = self.through._meta.get_field('content_object').rel.get_accessor_name()
+        rel_name = self.through._meta.get_field('content_object').remote_field.get_accessor_name()
         return getattr(instance, rel_name).all()

--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -463,7 +463,7 @@ class ParentalManyToManyField(ManyToManyField):
         # So, we'll let the original contribute_to_class do its thing, and then overwrite
         # the accessor...
         super(ParentalManyToManyField, self).contribute_to_class(cls, name, **kwargs)
-        setattr(cls, self.name, self.related_accessor_class(self.rel))
+        setattr(cls, self.name, self.related_accessor_class(self.remote_field))
 
     def value_from_object(self, obj):
         # In Django >=1.10, ManyToManyField.value_from_object special-cases objects with no PK,

--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -66,6 +66,11 @@ def create_deferring_foreign_related_manager(related, original_manager_cls):
 
             return FakeQuerySet(related.related_model, results)
 
+        def _apply_rel_filters(self, queryset):
+            # Implemented as empty for compatibility sake
+            # But there is probably a better implementation of this function
+            return queryset._next_is_sticky()
+
         def get_prefetch_queryset(self, instances, queryset=None):
             if queryset is None:
                 db = self._db or router.db_for_read(self.model, instance=instances[0])
@@ -83,7 +88,10 @@ def create_deferring_foreign_related_manager(related, original_manager_cls):
                 instance = instances_dict[rel_obj_attr(rel_obj)]
                 setattr(rel_obj, rel_field.name, instance)
             cache_name = rel_field.related_query_name()
-            return qs, rel_obj_attr, instance_attr, False, cache_name
+            if django.VERSION >= (2, 0):
+                return qs, rel_obj_attr, instance_attr, False, cache_name, False
+            else:
+                return qs, rel_obj_attr, instance_attr, False, cache_name
 
         def get_object_list(self):
             """

--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -254,12 +254,12 @@ class ParentalKey(ForeignKey):
         # If self.rel.to is a string at this point, it means that Django has been unable
         # to resolve it as a model name; if so, skip this test so that Django's own
         # system checks can report the appropriate error
-        if isinstance(self.rel.to, type) and not issubclass(self.rel.to, ClusterableModel):
+        if isinstance(self.remote_field.model, type) and not issubclass(self.remote_field.model, ClusterableModel):
             errors.append(
                 checks.Error(
                     'ParentalKey must point to a subclass of ClusterableModel.',
                     hint='Change {model_name} into a ClusterableModel or use a ForeignKey instead.'.format(
-                        model_name=self.rel.to._meta.app_label + '.' + self.rel.to.__name__,
+                        model_name=self.remote_field.model._meta.app_label + '.' + self.remote_field.model.__name__,
                     ),
                     obj=self,
                     id='modelcluster.E001',
@@ -267,7 +267,7 @@ class ParentalKey(ForeignKey):
             )
 
         # ParentalKeys must have an accessor name (#49)
-        if self.rel.get_accessor_name() == '+':
+        if self.remote_field.get_accessor_name() == '+':
             errors.append(
                 checks.Error(
                     "related_name='+' is not allowed on ParentalKey fields",

--- a/modelcluster/forms.py
+++ b/modelcluster/forms.py
@@ -84,11 +84,11 @@ def transientmodelformset_factory(model, formset=BaseTransientModelFormSet, **kw
 class BaseChildFormSet(BaseTransientModelFormSet):
     def __init__(self, data=None, files=None, instance=None, queryset=None, **kwargs):
         if instance is None:
-            self.instance = self.fk.rel.to()
+            self.instance = self.fk.remote_field.model()
         else:
             self.instance = instance
 
-        self.rel_name = ForeignObjectRel(self.fk, self.fk.rel.to, related_name=self.fk.rel.related_name).get_accessor_name()
+        self.rel_name = ForeignObjectRel(self.fk, self.fk.remote_field.model, related_name=self.fk.remote_field.related_name).get_accessor_name()
 
         if queryset is None:
             queryset = getattr(self.instance, self.rel_name).all()

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -41,7 +41,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(max_length=255)),
-                ('band', modelcluster.fields.ParentalKey(related_name='members', to='tests.Band')),
+                ('band', modelcluster.fields.ParentalKey(related_name='members', to='tests.Band', on_delete=django.db.models.deletion.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -74,7 +74,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('price', models.DecimalField(max_digits=6, decimal_places=2)),
-                ('dish', models.ForeignKey(related_name='+', to='tests.Dish')),
+                ('dish', models.ForeignKey(related_name='+', to='tests.Dish', on_delete=django.db.models.deletion.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -114,7 +114,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Restaurant',
             fields=[
-                ('place_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.Place')),
+                ('place_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='tests.Place', on_delete=django.db.models.deletion.CASCADE)),
                 ('serves_hot_dogs', models.BooleanField(default=False)),
                 ('proprietor', models.ForeignKey(related_name='restaurants', on_delete=django.db.models.deletion.SET_NULL, blank=True, to='tests.Chef', null=True)),
             ],
@@ -137,17 +137,17 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='taggedplace',
             name='content_object',
-            field=modelcluster.fields.ParentalKey(related_name='tagged_items', to='tests.Place'),
+            field=modelcluster.fields.ParentalKey(related_name='tagged_items', to='tests.Place', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='taggedplace',
             name='tag',
-            field=models.ForeignKey(related_name='tests_taggedplace_items', to='taggit.Tag'),
+            field=models.ForeignKey(related_name='tests_taggedplace_items', to='taggit.Tag', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='review',
             name='place',
-            field=modelcluster.fields.ParentalKey(related_name='reviews', to='tests.Place'),
+            field=modelcluster.fields.ParentalKey(related_name='reviews', to='tests.Place', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='place',
@@ -162,11 +162,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='album',
             name='band',
-            field=modelcluster.fields.ParentalKey(related_name='albums', to='tests.Band'),
+            field=modelcluster.fields.ParentalKey(related_name='albums', to='tests.Band', on_delete=django.db.models.deletion.CASCADE),
         ),
         migrations.AddField(
             model_name='menuitem',
             name='restaurant',
-            field=modelcluster.fields.ParentalKey(related_name='menu_items', to='tests.Restaurant'),
+            field=modelcluster.fields.ParentalKey(related_name='menu_items', to='tests.Restaurant', on_delete=django.db.models.deletion.CASCADE),
         ),
     ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -21,7 +21,7 @@ class Band(ClusterableModel):
 
 @python_2_unicode_compatible
 class BandMember(models.Model):
-    band = ParentalKey('Band', related_name='members')
+    band = ParentalKey('Band', related_name='members', on_delete=models.CASCADE)
     name = models.CharField(max_length=255)
 
     def __str__(self):
@@ -30,7 +30,7 @@ class BandMember(models.Model):
 
 @python_2_unicode_compatible
 class Album(models.Model):
-    band = ParentalKey('Band', related_name='albums')
+    band = ParentalKey('Band', related_name='albums', on_delete=models.CASCADE)
     name = models.CharField(max_length=255)
     release_date = models.DateField(null=True, blank=True)
     sort_order = models.IntegerField(null=True, blank=True, editable=False)
@@ -45,7 +45,7 @@ class Album(models.Model):
 
 
 class TaggedPlace(TaggedItemBase):
-    content_object = ParentalKey('Place', related_name='tagged_items')
+    content_object = ParentalKey('Place', related_name='tagged_items', on_delete=models.CASCADE)
 
 
 @python_2_unicode_compatible
@@ -106,7 +106,7 @@ class Chef(models.Model):
 
 @python_2_unicode_compatible
 class MenuItem(models.Model):
-    restaurant = ParentalKey('Restaurant', related_name='menu_items')
+    restaurant = ParentalKey('Restaurant', related_name='menu_items', on_delete=models.CASCADE)
     dish = models.ForeignKey('Dish', related_name='+', on_delete=models.CASCADE)
     price = models.DecimalField(max_digits=6, decimal_places=2)
     recommended_wine = models.ForeignKey('Wine', null=True, blank=True, on_delete=models.SET_NULL, related_name='+')
@@ -117,7 +117,7 @@ class MenuItem(models.Model):
 
 @python_2_unicode_compatible
 class Review(models.Model):
-    place = ParentalKey('Place', related_name='reviews')
+    place = ParentalKey('Place', related_name='reviews', on_delete=models.CASCADE)
     author = models.CharField(max_length=255)
     body = models.TextField()
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -63,7 +63,7 @@ class Restaurant(Place):
 
 
 class TaggedNonClusterPlace(TaggedItemBase):
-    content_object = models.ForeignKey('NonClusterPlace', related_name='tagged_items')
+    content_object = models.ForeignKey('NonClusterPlace', related_name='tagged_items', on_delete=models.CASCADE)
 
 
 @python_2_unicode_compatible
@@ -107,7 +107,7 @@ class Chef(models.Model):
 @python_2_unicode_compatible
 class MenuItem(models.Model):
     restaurant = ParentalKey('Restaurant', related_name='menu_items')
-    dish = models.ForeignKey('Dish', related_name='+')
+    dish = models.ForeignKey('Dish', related_name='+', on_delete=models.CASCADE)
     price = models.DecimalField(max_digits=6, decimal_places=2)
     recommended_wine = models.ForeignKey('Wine', null=True, blank=True, on_delete=models.SET_NULL, related_name='+')
 

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -242,7 +242,7 @@ class ClusterTest(TestCase):
 
         class Instrument(models.Model):
             # Oops, BandMember is not a Clusterable model
-            member = ParentalKey(BandMember)
+            member = ParentalKey(BandMember, on_delete=models.CASCADE)
 
             class Meta:
                 # Prevent Django from thinking this is in the database
@@ -268,7 +268,7 @@ class ClusterTest(TestCase):
 
         class Instrument(models.Model):
             # Oops, related_name='+' is not allowed
-            band = ParentalKey(Band, related_name='+')
+            band = ParentalKey(Band, related_name='+', on_delete=models.CASCADE)
 
             class Meta:
                 # Prevent Django from thinking this is in the database
@@ -293,7 +293,7 @@ class ClusterTest(TestCase):
         from modelcluster.fields import ParentalKey
 
         class Instrument(models.Model):
-            banana = ParentalKey('Banana')
+            banana = ParentalKey('Banana', on_delete=models.CASCADE)
 
             class Meta:
                 # Prevent Django from thinking this is in the database

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,9 @@ basepython =
     py35: python3.5
     py36: python3.6
 
+# temporarily install jdufresne's dj20 fork of django-taggit until dj20 support is merged and released
 deps =
-    django-taggit>=0.20.0
+    git+https://github.com/jdufresne/django-taggit.git@dj20
     pytz>=2014.7
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py{27,33,34}-dj{18}-{sqlite,postgres}
     py{27,34,35}-dj{19,110}-{sqlite,postgres}
     py{27,35,36}-dj111-{sqlite,postgres}
+    py{34,35,36}-dj20-{sqlite,postgres}
 
 [testenv]
 commands=./runtests.py --noinput
@@ -21,6 +22,7 @@ deps =
     dj19: Django>=1.9,<1.10
     dj110: Django>=1.10,<1.11
     dj111: Django>=1.11,<2.0
+    dj20: Django>=2.0rc1,<2.1
     postgres: psycopg2>=2.6
 
 setenv =


### PR DESCRIPTION
Rename `field.rel` to `field.remote_field` (django.db.models.fields.Field)
Rename `field.rel.to` to `field.remote_field.model` (django.db.models.fields.reverse_related.ForeignObjectRel)

Drop code for supporting Django 1.8 and below.