### PR TITLE
Make ParentalKey default to on_delete=CASCADE

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+4.1 (xx.xx.xxxx)
+~~~~~~~~~~~~~~~~
+* `on_delete` on ParentalKey now defaults to CASCADE if not specified
+
 4.0 (13.12.2017)
 ~~~~~~~~~~~~~~~~
 * Django 2.0 compatibility

--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import django
 from django.core import checks
 from django.db import IntegrityError, router
+from django.db.models import CASCADE
 from django.db.models.fields.related import ForeignKey, ManyToManyField
 from django.utils.functional import cached_property
 
@@ -236,6 +237,10 @@ class ChildObjectsDescriptor(ReverseManyToOneDescriptor):
 
 class ParentalKey(ForeignKey):
     related_accessor_class = ChildObjectsDescriptor
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('on_delete', CASCADE)
+        super(ParentalKey, self).__init__(*args, **kwargs)
 
     def check(self, **kwargs):
         from modelcluster.models import ClusterableModel

--- a/tests/models.py
+++ b/tests/models.py
@@ -33,7 +33,7 @@ class BandMember(models.Model):
 
 @python_2_unicode_compatible
 class Album(models.Model):
-    band = ParentalKey('Band', related_name='albums', on_delete=models.CASCADE)
+    band = ParentalKey('Band', related_name='albums')
     name = models.CharField(max_length=255)
     release_date = models.DateField(null=True, blank=True)
     sort_order = models.IntegerField(null=True, blank=True, editable=False)


### PR DESCRIPTION
Fixes https://github.com/wagtail/django-modelcluster/issues/89#issuecomment-363515427