### PR TITLE
Implement filter lookup expressions on FakeQuerySet

### DIFF
--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -126,6 +126,31 @@ def test_date(model, attribute_name, match_value):
     return _test
 
 
+def test_year(model, attribute_name, value):
+    value_int = int(value)
+    return lambda obj: getattr(obj, attribute_name).year == value_int
+
+
+def test_month(model, attribute_name, value):
+    value_int = int(value)
+    return lambda obj: getattr(obj, attribute_name).month == value_int
+
+
+def test_day(model, attribute_name, value):
+    value_int = int(value)
+    return lambda obj: getattr(obj, attribute_name).day == value_int
+
+
+def test_week(model, attribute_name, value):
+    value_int = int(value)
+    return lambda obj: getattr(obj, attribute_name).isocalendar()[1] == value_int
+
+
+def test_week_day(model, attribute_name, value):
+    value_int = int(value)
+    return lambda obj: getattr(obj, attribute_name).isoweekday() % 7 + 1 == value_int
+
+
 FILTER_EXPRESSION_TOKENS = {
     'exact': test_exact,
     'iexact': test_iexact,
@@ -142,6 +167,11 @@ FILTER_EXPRESSION_TOKENS = {
     'iendswith': test_iendswith,
     'range': test_range,
     'date': test_date,
+    'year': test_year,
+    'month': test_month,
+    'day': test_day,
+    'week': test_week,
+    'week_day': test_week_day,
 }
 
 

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import datetime
+
 from django.db.models import Model, prefetch_related_objects
 
 from modelcluster.utils import sort_by_fields
@@ -113,6 +115,17 @@ def test_range(model, attribute_name, range_val):
     return _test
 
 
+def test_date(model, attribute_name, match_value):
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        if isinstance(val, datetime.datetime):
+            return val.date() == match_value
+        else:
+            return val == match_value
+
+    return _test
+
+
 FILTER_EXPRESSION_TOKENS = {
     'exact': test_exact,
     'iexact': test_iexact,
@@ -128,6 +141,7 @@ FILTER_EXPRESSION_TOKENS = {
     'endswith': test_endswith,
     'iendswith': test_iendswith,
     'range': test_range,
+    'date': test_date,
 }
 
 

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -101,6 +101,18 @@ def test_iendswith(model, attribute_name, value):
     return lambda obj: getattr(obj, attribute_name).upper().endswith(match_value)
 
 
+def test_range(model, attribute_name, range_val):
+    field = model._meta.get_field(attribute_name)
+    start_val = field.to_python(range_val[0])
+    end_val = field.to_python(range_val[1])
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return (val >= start_val and val <= end_val)
+
+    return _test
+
+
 FILTER_EXPRESSION_TOKENS = {
     'exact': test_exact,
     'iexact': test_iexact,
@@ -115,6 +127,7 @@ FILTER_EXPRESSION_TOKENS = {
     'istartswith': test_istartswith,
     'endswith': test_endswith,
     'iendswith': test_iendswith,
+    'range': test_range,
 }
 
 

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -31,46 +31,86 @@ def test_exact(model, attribute_name, value):
         return lambda obj: getattr(obj, attribute_name) == typed_value
 
 
-def test_iexact(model, attribute_name, value):
+def test_iexact(model, attribute_name, match_value):
     field = model._meta.get_field(attribute_name)
-    match_value = field.to_python(value).upper()
-    return lambda obj: getattr(obj, attribute_name).upper() == match_value
+    match_value = field.to_python(match_value)
+
+    if match_value is None:
+        return lambda obj: getattr(obj, attribute_name) is None
+    else:
+        match_value = match_value.upper()
+
+        def _test(obj):
+            val = getattr(obj, attribute_name)
+            return val is not None and val.upper() == match_value
+
+        return _test
 
 
 def test_contains(model, attribute_name, value):
     field = model._meta.get_field(attribute_name)
     match_value = field.to_python(value)
-    return lambda obj: match_value in getattr(obj, attribute_name)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and match_value in val
+
+    return _test
 
 
 def test_icontains(model, attribute_name, value):
     field = model._meta.get_field(attribute_name)
     match_value = field.to_python(value).upper()
-    return lambda obj: match_value in getattr(obj, attribute_name).upper()
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and match_value in val.upper()
+
+    return _test
 
 
 def test_lt(model, attribute_name, value):
     field = model._meta.get_field(attribute_name)
     match_value = field.to_python(value)
-    return lambda obj: getattr(obj, attribute_name) < match_value
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val < match_value
+
+    return _test
 
 
 def test_lte(model, attribute_name, value):
     field = model._meta.get_field(attribute_name)
     match_value = field.to_python(value)
-    return lambda obj: getattr(obj, attribute_name) <= match_value
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val <= match_value
+
+    return _test
 
 
 def test_gt(model, attribute_name, value):
     field = model._meta.get_field(attribute_name)
     match_value = field.to_python(value)
-    return lambda obj: getattr(obj, attribute_name) > match_value
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val > match_value
+
+    return _test
 
 
 def test_gte(model, attribute_name, value):
     field = model._meta.get_field(attribute_name)
     match_value = field.to_python(value)
-    return lambda obj: getattr(obj, attribute_name) >= match_value
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val >= match_value
+
+    return _test
 
 
 def test_in(model, attribute_name, value_list):
@@ -82,25 +122,45 @@ def test_in(model, attribute_name, value_list):
 def test_startswith(model, attribute_name, value):
     field = model._meta.get_field(attribute_name)
     match_value = field.to_python(value)
-    return lambda obj: getattr(obj, attribute_name).startswith(match_value)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val.startswith(match_value)
+
+    return _test
 
 
 def test_istartswith(model, attribute_name, value):
     field = model._meta.get_field(attribute_name)
     match_value = field.to_python(value).upper()
-    return lambda obj: getattr(obj, attribute_name).upper().startswith(match_value)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val.upper().startswith(match_value)
+
+    return _test
 
 
 def test_endswith(model, attribute_name, value):
     field = model._meta.get_field(attribute_name)
     match_value = field.to_python(value)
-    return lambda obj: getattr(obj, attribute_name).endswith(match_value)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val.endswith(match_value)
+
+    return _test
 
 
 def test_iendswith(model, attribute_name, value):
     field = model._meta.get_field(attribute_name)
     match_value = field.to_python(value).upper()
-    return lambda obj: getattr(obj, attribute_name).upper().endswith(match_value)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val.upper().endswith(match_value)
+
+    return _test
 
 
 def test_range(model, attribute_name, range_val):

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import datetime
+import re
 
 from django.db.models import Model, prefetch_related_objects
 
@@ -294,6 +295,26 @@ def test_isnull(model, attribute_name, sense):
         return lambda obj: getattr(obj, attribute_name) is not None
 
 
+def test_regex(model, attribute_name, regex_string):
+    regex = re.compile(regex_string)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and regex.search(val)
+
+    return _test
+
+
+def test_iregex(model, attribute_name, regex_string):
+    regex = re.compile(regex_string, re.I)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and regex.search(val)
+
+    return _test
+
+
 FILTER_EXPRESSION_TOKENS = {
     'exact': test_exact,
     'iexact': test_iexact,
@@ -321,6 +342,8 @@ FILTER_EXPRESSION_TOKENS = {
     'minute': test_minute,
     'second': test_second,
     'isnull': test_isnull,
+    'regex': test_regex,
+    'iregex': test_iregex,
 }
 
 

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -71,6 +71,12 @@ def test_gte(model, attribute_name, value):
     return lambda obj: getattr(obj, attribute_name) >= match_value
 
 
+def test_in(model, attribute_name, value_list):
+    field = model._meta.get_field(attribute_name)
+    match_values = set(field.to_python(val) for val in value_list)
+    return lambda obj: getattr(obj, attribute_name) in match_values
+
+
 FILTER_EXPRESSION_TOKENS = {
     'exact': test_exact,
     'iexact': test_iexact,
@@ -80,6 +86,7 @@ FILTER_EXPRESSION_TOKENS = {
     'lte': test_lte,
     'gt': test_gt,
     'gte': test_gte,
+    'in': test_in,
 }
 
 

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -35,6 +35,18 @@ def test_iexact(model, attribute_name, value):
     return lambda obj: getattr(obj, attribute_name).upper() == match_value
 
 
+def test_contains(model, attribute_name, value):
+    field = model._meta.get_field(attribute_name)
+    match_value = field.to_python(value)
+    return lambda obj: match_value in getattr(obj, attribute_name)
+
+
+def test_icontains(model, attribute_name, value):
+    field = model._meta.get_field(attribute_name)
+    match_value = field.to_python(value).upper()
+    return lambda obj: match_value in getattr(obj, attribute_name).upper()
+
+
 def test_lt(model, attribute_name, value):
     field = model._meta.get_field(attribute_name)
     match_value = field.to_python(value)
@@ -62,6 +74,8 @@ def test_gte(model, attribute_name, value):
 FILTER_EXPRESSION_TOKENS = {
     'exact': test_exact,
     'iexact': test_iexact,
+    'contains': test_contains,
+    'icontains': test_icontains,
     'lt': test_lt,
     'lte': test_lte,
     'gt': test_gt,

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -35,9 +35,16 @@ def test_iexact(model, attribute_name, value):
     return lambda obj: getattr(obj, attribute_name).upper() == match_value
 
 
+def test_lt(model, attribute_name, value):
+    field = model._meta.get_field(attribute_name)
+    match_value = field.to_python(value)
+    return lambda obj: getattr(obj, attribute_name) < match_value
+
+
 FILTER_EXPRESSION_TOKENS = {
     'exact': test_exact,
     'iexact': test_iexact,
+    'lt': test_lt,
 }
 
 

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -77,6 +77,30 @@ def test_in(model, attribute_name, value_list):
     return lambda obj: getattr(obj, attribute_name) in match_values
 
 
+def test_startswith(model, attribute_name, value):
+    field = model._meta.get_field(attribute_name)
+    match_value = field.to_python(value)
+    return lambda obj: getattr(obj, attribute_name).startswith(match_value)
+
+
+def test_istartswith(model, attribute_name, value):
+    field = model._meta.get_field(attribute_name)
+    match_value = field.to_python(value).upper()
+    return lambda obj: getattr(obj, attribute_name).upper().startswith(match_value)
+
+
+def test_endswith(model, attribute_name, value):
+    field = model._meta.get_field(attribute_name)
+    match_value = field.to_python(value)
+    return lambda obj: getattr(obj, attribute_name).endswith(match_value)
+
+
+def test_iendswith(model, attribute_name, value):
+    field = model._meta.get_field(attribute_name)
+    match_value = field.to_python(value).upper()
+    return lambda obj: getattr(obj, attribute_name).upper().endswith(match_value)
+
+
 FILTER_EXPRESSION_TOKENS = {
     'exact': test_exact,
     'iexact': test_iexact,
@@ -87,6 +111,10 @@ FILTER_EXPRESSION_TOKENS = {
     'gt': test_gt,
     'gte': test_gte,
     'in': test_in,
+    'startswith': test_startswith,
+    'istartswith': test_istartswith,
+    'endswith': test_endswith,
+    'iendswith': test_iendswith,
 }
 
 

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -151,6 +151,37 @@ def test_week_day(model, attribute_name, value):
     return lambda obj: getattr(obj, attribute_name).isoweekday() % 7 + 1 == value_int
 
 
+def test_quarter(model, attribute_name, value):
+    value_int = int(value)
+    return lambda obj: int((getattr(obj, attribute_name).month - 1) / 3) + 1 == value_int
+
+
+def test_time(model, attribute_name, match_value):
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        if isinstance(val, datetime.datetime):
+            return val.time() == match_value
+        else:
+            return val == match_value
+
+    return _test
+
+
+def test_hour(model, attribute_name, value):
+    value_int = int(value)
+    return lambda obj: getattr(obj, attribute_name).hour == value_int
+
+
+def test_minute(model, attribute_name, value):
+    value_int = int(value)
+    return lambda obj: getattr(obj, attribute_name).minute == value_int
+
+
+def test_second(model, attribute_name, value):
+    value_int = int(value)
+    return lambda obj: getattr(obj, attribute_name).second == value_int
+
+
 FILTER_EXPRESSION_TOKENS = {
     'exact': test_exact,
     'iexact': test_iexact,
@@ -172,6 +203,11 @@ FILTER_EXPRESSION_TOKENS = {
     'day': test_day,
     'week': test_week,
     'week_day': test_week_day,
+    'quarter': test_quarter,
+    'time': test_time,
+    'hour': test_hour,
+    'minute': test_minute,
+    'second': test_second,
 }
 
 

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -287,6 +287,13 @@ def test_second(model, attribute_name, match_value):
     return _test
 
 
+def test_isnull(model, attribute_name, sense):
+    if sense:
+        return lambda obj: getattr(obj, attribute_name) is None
+    else:
+        return lambda obj: getattr(obj, attribute_name) is not None
+
+
 FILTER_EXPRESSION_TOKENS = {
     'exact': test_exact,
     'iexact': test_iexact,
@@ -313,6 +320,7 @@ FILTER_EXPRESSION_TOKENS = {
     'hour': test_hour,
     'minute': test_minute,
     'second': test_second,
+    'isnull': test_isnull,
 }
 
 

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -41,10 +41,31 @@ def test_lt(model, attribute_name, value):
     return lambda obj: getattr(obj, attribute_name) < match_value
 
 
+def test_lte(model, attribute_name, value):
+    field = model._meta.get_field(attribute_name)
+    match_value = field.to_python(value)
+    return lambda obj: getattr(obj, attribute_name) <= match_value
+
+
+def test_gt(model, attribute_name, value):
+    field = model._meta.get_field(attribute_name)
+    match_value = field.to_python(value)
+    return lambda obj: getattr(obj, attribute_name) > match_value
+
+
+def test_gte(model, attribute_name, value):
+    field = model._meta.get_field(attribute_name)
+    match_value = field.to_python(value)
+    return lambda obj: getattr(obj, attribute_name) >= match_value
+
+
 FILTER_EXPRESSION_TOKENS = {
     'exact': test_exact,
     'iexact': test_iexact,
     'lt': test_lt,
+    'lte': test_lte,
+    'gt': test_gt,
+    'gte': test_gte,
 }
 
 

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -110,7 +110,7 @@ def test_range(model, attribute_name, range_val):
 
     def _test(obj):
         val = getattr(obj, attribute_name)
-        return (val >= start_val and val <= end_val)
+        return (val is not None and val >= start_val and val <= end_val)
 
     return _test
 
@@ -126,34 +126,64 @@ def test_date(model, attribute_name, match_value):
     return _test
 
 
-def test_year(model, attribute_name, value):
-    value_int = int(value)
-    return lambda obj: getattr(obj, attribute_name).year == value_int
+def test_year(model, attribute_name, match_value):
+    match_value = int(match_value)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val.year == match_value
+
+    return _test
 
 
-def test_month(model, attribute_name, value):
-    value_int = int(value)
-    return lambda obj: getattr(obj, attribute_name).month == value_int
+def test_month(model, attribute_name, match_value):
+    match_value = int(match_value)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val.month == match_value
+
+    return _test
 
 
-def test_day(model, attribute_name, value):
-    value_int = int(value)
-    return lambda obj: getattr(obj, attribute_name).day == value_int
+def test_day(model, attribute_name, match_value):
+    match_value = int(match_value)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val.day == match_value
+
+    return _test
 
 
-def test_week(model, attribute_name, value):
-    value_int = int(value)
-    return lambda obj: getattr(obj, attribute_name).isocalendar()[1] == value_int
+def test_week(model, attribute_name, match_value):
+    match_value = int(match_value)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val.isocalendar()[1] == match_value
+
+    return _test
 
 
-def test_week_day(model, attribute_name, value):
-    value_int = int(value)
-    return lambda obj: getattr(obj, attribute_name).isoweekday() % 7 + 1 == value_int
+def test_week_day(model, attribute_name, match_value):
+    match_value = int(match_value)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val.isoweekday() % 7 + 1 == match_value
+
+    return _test
 
 
-def test_quarter(model, attribute_name, value):
-    value_int = int(value)
-    return lambda obj: int((getattr(obj, attribute_name).month - 1) / 3) + 1 == value_int
+def test_quarter(model, attribute_name, match_value):
+    match_value = int(match_value)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and int((val.month - 1) / 3) + 1 == match_value
+
+    return _test
 
 
 def test_time(model, attribute_name, match_value):
@@ -167,19 +197,34 @@ def test_time(model, attribute_name, match_value):
     return _test
 
 
-def test_hour(model, attribute_name, value):
-    value_int = int(value)
-    return lambda obj: getattr(obj, attribute_name).hour == value_int
+def test_hour(model, attribute_name, match_value):
+    match_value = int(match_value)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val.hour == match_value
+
+    return _test
 
 
-def test_minute(model, attribute_name, value):
-    value_int = int(value)
-    return lambda obj: getattr(obj, attribute_name).minute == value_int
+def test_minute(model, attribute_name, match_value):
+    match_value = int(match_value)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val.minute == match_value
+
+    return _test
 
 
-def test_second(model, attribute_name, value):
-    value_int = int(value)
-    return lambda obj: getattr(obj, attribute_name).second == value_int
+def test_second(model, attribute_name, match_value):
+    match_value = int(match_value)
+
+    def _test(obj):
+        val = getattr(obj, attribute_name)
+        return val is not None and val.second == match_value
+
+    return _test
 
 
 FILTER_EXPRESSION_TOKENS = {

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -29,8 +29,15 @@ def test_exact(model, attribute_name, value):
         return lambda obj: getattr(obj, attribute_name) == typed_value
 
 
+def test_iexact(model, attribute_name, value):
+    field = model._meta.get_field(attribute_name)
+    match_value = field.to_python(value).upper()
+    return lambda obj: getattr(obj, attribute_name).upper() == match_value
+
+
 FILTER_EXPRESSION_TOKENS = {
     'exact': test_exact,
+    'iexact': test_iexact,
 }
 
 

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -30,6 +30,13 @@ class ClusterTest(TestCase):
         self.assertEqual('Paul McCartney', beatles.members.filter(name__exact='Paul McCartney')[0].name)
         self.assertEqual('Paul McCartney', beatles.members.filter(name__iexact='paul mccartNEY')[0].name)
 
+        self.assertEqual(0, beatles.members.filter(name__lt='B').count())
+        self.assertEqual(1, beatles.members.filter(name__lt='M').count())
+        self.assertEqual('John Lennon', beatles.members.filter(name__lt='M')[0].name)
+        self.assertEqual(1, beatles.members.filter(name__lt='Paul McCartney').count())
+        self.assertEqual('John Lennon', beatles.members.filter(name__lt='Paul McCartney')[0].name)
+        self.assertEqual(2, beatles.members.filter(name__lt='Z').count())
+
         self.assertEqual('Paul McCartney', beatles.members.get(name='Paul McCartney').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__exact='Paul McCartney').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__iexact='paul mccartNEY').name)
@@ -239,6 +246,11 @@ class ClusterTest(TestCase):
         self.assertEqual('John Lennon', beatles.members.exclude(name__exact='Paul McCartney').first().name)
         self.assertEqual(1, beatles.members.exclude(name__iexact='paul mccartNEY').count())
         self.assertEqual('John Lennon', beatles.members.exclude(name__iexact='paul mccartNEY').first().name)
+
+        self.assertEqual(1, beatles.members.exclude(name__lt='M').count())
+        self.assertEqual('Paul McCartney', beatles.members.exclude(name__lt='M').first().name)
+        self.assertEqual(1, beatles.members.exclude(name__lt='Paul McCartney').count())
+        self.assertEqual('Paul McCartney', beatles.members.exclude(name__lt='Paul McCartney').first().name)
 
     def test_prefetch_related(self):
         Band.objects.create(name='The Beatles', members=[

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -55,6 +55,11 @@ class ClusterTest(TestCase):
         self.assertEqual('Paul McCartney', beatles.members.filter(name__gte='Paul McCartney')[0].name)
         self.assertEqual(0, beatles.members.filter(name__gte='Z').count())
 
+        self.assertEqual(1, beatles.members.filter(name__contains='Cart').count())
+        self.assertEqual('Paul McCartney', beatles.members.filter(name__contains='Cart')[0].name)
+        self.assertEqual(1, beatles.members.filter(name__icontains='carT').count())
+        self.assertEqual('Paul McCartney', beatles.members.filter(name__icontains='carT')[0].name)
+
         self.assertEqual('Paul McCartney', beatles.members.get(name='Paul McCartney').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__exact='Paul McCartney').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__iexact='paul mccartNEY').name)
@@ -62,6 +67,8 @@ class ClusterTest(TestCase):
         self.assertEqual('John Lennon', beatles.members.get(name__lte='M').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__gt='M').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__gte='Paul McCartney').name)
+        self.assertEqual('Paul McCartney', beatles.members.get(name__contains='Cart').name)
+        self.assertEqual('Paul McCartney', beatles.members.get(name__icontains='carT').name)
 
         self.assertRaises(BandMember.DoesNotExist, lambda: beatles.members.get(name='Reginald Dwight'))
         self.assertRaises(BandMember.MultipleObjectsReturned, lambda: beatles.members.get())
@@ -281,6 +288,11 @@ class ClusterTest(TestCase):
         self.assertEqual('John Lennon', beatles.members.exclude(name__gt='M').first().name)
         self.assertEqual(1, beatles.members.exclude(name__gte='Paul McCartney').count())
         self.assertEqual('John Lennon', beatles.members.exclude(name__gte='Paul McCartney').first().name)
+
+        self.assertEqual(1, beatles.members.exclude(name__contains='Cart').count())
+        self.assertEqual('John Lennon', beatles.members.exclude(name__contains='Cart').first().name)
+        self.assertEqual(1, beatles.members.exclude(name__icontains='carT').count())
+        self.assertEqual('John Lennon', beatles.members.exclude(name__icontains='carT').first().name)
 
     def test_prefetch_related(self):
         Band.objects.create(name='The Beatles', members=[

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -325,6 +325,43 @@ class ClusterTest(TestCase):
         self.assertEqual(1, beatles.members.exclude(name__iendswith='Ney').count())
         self.assertEqual('John Lennon', beatles.members.exclude(name__iendswith='Ney').first().name)
 
+    def test_queryset_filter_with_nulls(self):
+        tmbg = Band(name="They Might Be Giants", albums=[
+            Album(name="Flood", release_date=datetime.date(1990, 1, 1)),
+            Album(name="John Henry", release_date=datetime.date(1994, 7, 21)),
+            Album(name="Factory Showroom", release_date=datetime.date(1996, 3, 30)),
+            Album(name="", release_date=None),
+            Album(name=None, release_date=None),
+        ])
+
+        self.assertEqual(tmbg.albums.get(name="Flood").name, "Flood")
+        self.assertEqual(tmbg.albums.get(name="").name, "")
+        self.assertEqual(tmbg.albums.get(name=None).name, None)
+
+        self.assertEqual(tmbg.albums.get(name__exact="Flood").name, "Flood")
+        self.assertEqual(tmbg.albums.get(name__exact="").name, "")
+        self.assertEqual(tmbg.albums.get(name__exact=None).name, None)
+
+        self.assertEqual(tmbg.albums.get(name__iexact="flood").name, "Flood")
+        self.assertEqual(tmbg.albums.get(name__iexact="").name, "")
+        self.assertEqual(tmbg.albums.get(name__iexact=None).name, None)
+
+        self.assertEqual(tmbg.albums.get(name__contains="loo").name, "Flood")
+        self.assertEqual(tmbg.albums.get(name__icontains="LOO").name, "Flood")
+        self.assertEqual(tmbg.albums.get(name__startswith="Flo").name, "Flood")
+        self.assertEqual(tmbg.albums.get(name__istartswith="flO").name, "Flood")
+        self.assertEqual(tmbg.albums.get(name__endswith="ood").name, "Flood")
+        self.assertEqual(tmbg.albums.get(name__iendswith="Ood").name, "Flood")
+
+        self.assertEqual(tmbg.albums.get(name__lt="A").name, "")
+        self.assertEqual(tmbg.albums.get(name__lte="A").name, "")
+        self.assertEqual(tmbg.albums.get(name__gt="J").name, "John Henry")
+        self.assertEqual(tmbg.albums.get(name__gte="J").name, "John Henry")
+
+        self.assertEqual(tmbg.albums.get(name__in=["Flood", "Mink Car"]).name, "Flood")
+        self.assertEqual(tmbg.albums.get(name__in=["", "Mink Car"]).name, "")
+        self.assertEqual(tmbg.albums.get(name__in=[None, "Mink Car"]).name, None)
+
     def test_date_filters(self):
         tmbg = Band(name="They Might Be Giants", albums=[
             Album(name="Flood", release_date=datetime.date(1990, 1, 1)),

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -25,10 +25,15 @@ class ClusterTest(TestCase):
         # we should be able to query this relation using (some) queryset methods
         self.assertEqual(2, beatles.members.count())
         self.assertEqual('John Lennon', beatles.members.all()[0].name)
+
         self.assertEqual('Paul McCartney', beatles.members.filter(name='Paul McCartney')[0].name)
         self.assertEqual('Paul McCartney', beatles.members.filter(name__exact='Paul McCartney')[0].name)
+        self.assertEqual('Paul McCartney', beatles.members.filter(name__iexact='paul mccartNEY')[0].name)
+
         self.assertEqual('Paul McCartney', beatles.members.get(name='Paul McCartney').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__exact='Paul McCartney').name)
+        self.assertEqual('Paul McCartney', beatles.members.get(name__iexact='paul mccartNEY').name)
+
         self.assertRaises(BandMember.DoesNotExist, lambda: beatles.members.get(name='Reginald Dwight'))
         self.assertRaises(BandMember.MultipleObjectsReturned, lambda: beatles.members.get())
 
@@ -231,6 +236,9 @@ class ClusterTest(TestCase):
         self.assertEqual('John Lennon', beatles.members.exclude(name='Paul McCartney').first().name)
 
         self.assertEqual(1, beatles.members.exclude(name__exact='Paul McCartney').count())
+        self.assertEqual('John Lennon', beatles.members.exclude(name__exact='Paul McCartney').first().name)
+        self.assertEqual(1, beatles.members.exclude(name__iexact='paul mccartNEY').count())
+        self.assertEqual('John Lennon', beatles.members.exclude(name__iexact='paul mccartNEY').first().name)
 
     def test_prefetch_related(self):
         Band.objects.create(name='The Beatles', members=[

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -362,6 +362,9 @@ class ClusterTest(TestCase):
         self.assertEqual(tmbg.albums.get(name__in=["", "Mink Car"]).name, "")
         self.assertEqual(tmbg.albums.get(name__in=[None, "Mink Car"]).name, None)
 
+        self.assertEqual(tmbg.albums.filter(name__isnull=True).count(), 1)
+        self.assertEqual(tmbg.albums.filter(name__isnull=False).count(), 4)
+
     def test_date_filters(self):
         tmbg = Band(name="They Might Be Giants", albums=[
             Album(name="Flood", release_date=datetime.date(1990, 1, 1)),

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -355,6 +355,51 @@ class ClusterTest(TestCase):
             "one person died"
         )
 
+        self.assertEqual(
+            tmbg.albums.get(release_date__year='1994').name,
+            "John Henry"
+        )
+        self.assertEqual(
+            logs.get(time__year=1980).data,
+            "one person died"
+        )
+
+        self.assertEqual(
+            tmbg.albums.get(release_date__month=7).name,
+            "John Henry"
+        )
+        self.assertEqual(
+            logs.get(time__month='2').data,
+            "one person died"
+        )
+
+        self.assertEqual(
+            tmbg.albums.get(release_date__day='21').name,
+            "John Henry"
+        )
+        self.assertEqual(
+            logs.get(time__day=2).data,
+            "one person died"
+        )
+
+        self.assertEqual(
+            tmbg.albums.get(release_date__week=29).name,
+            "John Henry"
+        )
+        self.assertEqual(
+            logs.get(time__week='5').data,
+            "one person died"
+        )
+
+        self.assertEqual(
+            tmbg.albums.get(release_date__week_day=5).name,
+            "John Henry"
+        )
+        self.assertEqual(
+            logs.get(time__week_day=7).data,
+            "one person died"
+        )
+
     def test_prefetch_related(self):
         Band.objects.create(name='The Beatles', members=[
             BandMember(id=1, name='John Lennon'),

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -26,7 +26,9 @@ class ClusterTest(TestCase):
         self.assertEqual(2, beatles.members.count())
         self.assertEqual('John Lennon', beatles.members.all()[0].name)
         self.assertEqual('Paul McCartney', beatles.members.filter(name='Paul McCartney')[0].name)
+        self.assertEqual('Paul McCartney', beatles.members.filter(name__exact='Paul McCartney')[0].name)
         self.assertEqual('Paul McCartney', beatles.members.get(name='Paul McCartney').name)
+        self.assertEqual('Paul McCartney', beatles.members.get(name__exact='Paul McCartney').name)
         self.assertRaises(BandMember.DoesNotExist, lambda: beatles.members.get(name='Reginald Dwight'))
         self.assertRaises(BandMember.MultipleObjectsReturned, lambda: beatles.members.get())
 
@@ -227,6 +229,8 @@ class ClusterTest(TestCase):
 
         self.assertEqual(1, beatles.members.exclude(name='Paul McCartney').count())
         self.assertEqual('John Lennon', beatles.members.exclude(name='Paul McCartney').first().name)
+
+        self.assertEqual(1, beatles.members.exclude(name__exact='Paul McCartney').count())
 
     def test_prefetch_related(self):
         Band.objects.create(name='The Beatles', members=[

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -89,6 +89,9 @@ class ClusterTest(TestCase):
         self.assertEqual('Paul McCartney', beatles.members.get(name__endswith='ney').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__iendswith='Ney').name)
 
+        self.assertEqual('John Lennon', beatles.members.get(name__regex=r'n{2}').name)
+        self.assertEqual('John Lennon', beatles.members.get(name__iregex=r'N{2}').name)
+
         self.assertRaises(BandMember.DoesNotExist, lambda: beatles.members.get(name='Reginald Dwight'))
         self.assertRaises(BandMember.MultipleObjectsReturned, lambda: beatles.members.get())
 
@@ -364,6 +367,9 @@ class ClusterTest(TestCase):
 
         self.assertEqual(tmbg.albums.filter(name__isnull=True).count(), 1)
         self.assertEqual(tmbg.albums.filter(name__isnull=False).count(), 4)
+
+        self.assertEqual(tmbg.albums.get(name__regex=r'l..d').name, "Flood")
+        self.assertEqual(tmbg.albums.get(name__iregex=r'f..o').name, "Flood")
 
     def test_date_filters(self):
         tmbg = Band(name="They Might Be Giants", albums=[

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -60,6 +60,9 @@ class ClusterTest(TestCase):
         self.assertEqual(1, beatles.members.filter(name__icontains='carT').count())
         self.assertEqual('Paul McCartney', beatles.members.filter(name__icontains='carT')[0].name)
 
+        self.assertEqual(1, beatles.members.filter(name__in=['Paul McCartney', 'Linda McCartney']).count())
+        self.assertEqual('Paul McCartney', beatles.members.filter(name__in=['Paul McCartney', 'Linda McCartney'])[0].name)
+
         self.assertEqual('Paul McCartney', beatles.members.get(name='Paul McCartney').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__exact='Paul McCartney').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__iexact='paul mccartNEY').name)
@@ -69,6 +72,7 @@ class ClusterTest(TestCase):
         self.assertEqual('Paul McCartney', beatles.members.get(name__gte='Paul McCartney').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__contains='Cart').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__icontains='carT').name)
+        self.assertEqual('Paul McCartney', beatles.members.get(name__in=['Paul McCartney', 'Linda McCartney']).name)
 
         self.assertRaises(BandMember.DoesNotExist, lambda: beatles.members.get(name='Reginald Dwight'))
         self.assertRaises(BandMember.MultipleObjectsReturned, lambda: beatles.members.get())
@@ -293,6 +297,9 @@ class ClusterTest(TestCase):
         self.assertEqual('John Lennon', beatles.members.exclude(name__contains='Cart').first().name)
         self.assertEqual(1, beatles.members.exclude(name__icontains='carT').count())
         self.assertEqual('John Lennon', beatles.members.exclude(name__icontains='carT').first().name)
+
+        self.assertEqual(1, beatles.members.exclude(name__in=['Paul McCartney', 'Linda McCartney']).count())
+        self.assertEqual('John Lennon', beatles.members.exclude(name__in=['Paul McCartney', 'Linda McCartney'])[0].name)
 
     def test_prefetch_related(self):
         Band.objects.create(name='The Beatles', members=[

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -330,11 +330,13 @@ class ClusterTest(TestCase):
             Album(name="Flood", release_date=datetime.date(1990, 1, 1)),
             Album(name="John Henry", release_date=datetime.date(1994, 7, 21)),
             Album(name="Factory Showroom", release_date=datetime.date(1996, 3, 30)),
+            Album(name="The Complete Dial-A-Song", release_date=None),
         ])
 
         logs = FakeQuerySet(Log, [
             Log(time=datetime.datetime(1979, 7, 1, 1, 1, 1), data="nobody died"),
             Log(time=datetime.datetime(1980, 2, 2, 2, 2, 2), data="one person died"),
+            Log(time=None, data="nothing happened")
         ])
 
         self.assertEqual(

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -346,6 +346,15 @@ class ClusterTest(TestCase):
             "one person died"
         )
 
+        self.assertEqual(
+            tmbg.albums.get(release_date__date=datetime.date(1994, 7, 21)).name,
+            "John Henry"
+        )
+        self.assertEqual(
+            logs.get(time__date=datetime.date(1980, 2, 2)).data,
+            "one person died"
+        )
+
     def test_prefetch_related(self):
         Band.objects.create(name='The Beatles', members=[
             BandMember(id=1, name='John Lennon'),

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -333,7 +333,7 @@ class ClusterTest(TestCase):
         ])
 
         logs = FakeQuerySet(Log, [
-            Log(time=datetime.datetime(1979, 1, 1, 1, 1, 1), data="nobody died"),
+            Log(time=datetime.datetime(1979, 7, 1, 1, 1, 1), data="nobody died"),
             Log(time=datetime.datetime(1980, 2, 2, 2, 2, 2), data="one person died"),
         ])
 
@@ -397,6 +397,35 @@ class ClusterTest(TestCase):
         )
         self.assertEqual(
             logs.get(time__week_day=7).data,
+            "one person died"
+        )
+
+        self.assertEqual(
+            tmbg.albums.get(release_date__quarter=3).name,
+            "John Henry"
+        )
+        self.assertEqual(
+            logs.get(time__quarter=1).data,
+            "one person died"
+        )
+
+        self.assertEqual(
+            logs.get(time__time=datetime.time(2, 2, 2)).data,
+            "one person died"
+        )
+
+        self.assertEqual(
+            logs.get(time__hour=2).data,
+            "one person died"
+        )
+
+        self.assertEqual(
+            logs.get(time__minute='2').data,
+            "one person died"
+        )
+
+        self.assertEqual(
+            logs.get(time__second=2).data,
             "one person died"
         )
 

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -37,9 +37,31 @@ class ClusterTest(TestCase):
         self.assertEqual('John Lennon', beatles.members.filter(name__lt='Paul McCartney')[0].name)
         self.assertEqual(2, beatles.members.filter(name__lt='Z').count())
 
+        self.assertEqual(0, beatles.members.filter(name__lte='B').count())
+        self.assertEqual(1, beatles.members.filter(name__lte='M').count())
+        self.assertEqual('John Lennon', beatles.members.filter(name__lte='M')[0].name)
+        self.assertEqual(2, beatles.members.filter(name__lte='Paul McCartney').count())
+        self.assertEqual(2, beatles.members.filter(name__lte='Z').count())
+
+        self.assertEqual(2, beatles.members.filter(name__gt='B').count())
+        self.assertEqual(1, beatles.members.filter(name__gt='M').count())
+        self.assertEqual('Paul McCartney', beatles.members.filter(name__gt='M')[0].name)
+        self.assertEqual(0, beatles.members.filter(name__gt='Paul McCartney').count())
+
+        self.assertEqual(2, beatles.members.filter(name__gte='B').count())
+        self.assertEqual(1, beatles.members.filter(name__gte='M').count())
+        self.assertEqual('Paul McCartney', beatles.members.filter(name__gte='M')[0].name)
+        self.assertEqual(1, beatles.members.filter(name__gte='Paul McCartney').count())
+        self.assertEqual('Paul McCartney', beatles.members.filter(name__gte='Paul McCartney')[0].name)
+        self.assertEqual(0, beatles.members.filter(name__gte='Z').count())
+
         self.assertEqual('Paul McCartney', beatles.members.get(name='Paul McCartney').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__exact='Paul McCartney').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__iexact='paul mccartNEY').name)
+        self.assertEqual('John Lennon', beatles.members.get(name__lt='Paul McCartney').name)
+        self.assertEqual('John Lennon', beatles.members.get(name__lte='M').name)
+        self.assertEqual('Paul McCartney', beatles.members.get(name__gt='M').name)
+        self.assertEqual('Paul McCartney', beatles.members.get(name__gte='Paul McCartney').name)
 
         self.assertRaises(BandMember.DoesNotExist, lambda: beatles.members.get(name='Reginald Dwight'))
         self.assertRaises(BandMember.MultipleObjectsReturned, lambda: beatles.members.get())
@@ -251,6 +273,14 @@ class ClusterTest(TestCase):
         self.assertEqual('Paul McCartney', beatles.members.exclude(name__lt='M').first().name)
         self.assertEqual(1, beatles.members.exclude(name__lt='Paul McCartney').count())
         self.assertEqual('Paul McCartney', beatles.members.exclude(name__lt='Paul McCartney').first().name)
+
+        self.assertEqual(1, beatles.members.exclude(name__lte='John Lennon').count())
+        self.assertEqual('Paul McCartney', beatles.members.exclude(name__lte='John Lennon').first().name)
+
+        self.assertEqual(1, beatles.members.exclude(name__gt='M').count())
+        self.assertEqual('John Lennon', beatles.members.exclude(name__gt='M').first().name)
+        self.assertEqual(1, beatles.members.exclude(name__gte='Paul McCartney').count())
+        self.assertEqual('John Lennon', beatles.members.exclude(name__gte='Paul McCartney').first().name)
 
     def test_prefetch_related(self):
         Band.objects.create(name='The Beatles', members=[

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -63,6 +63,15 @@ class ClusterTest(TestCase):
         self.assertEqual(1, beatles.members.filter(name__in=['Paul McCartney', 'Linda McCartney']).count())
         self.assertEqual('Paul McCartney', beatles.members.filter(name__in=['Paul McCartney', 'Linda McCartney'])[0].name)
 
+        self.assertEqual(1, beatles.members.filter(name__startswith='Paul').count())
+        self.assertEqual('Paul McCartney', beatles.members.filter(name__startswith='Paul')[0].name)
+        self.assertEqual(1, beatles.members.filter(name__istartswith='pauL').count())
+        self.assertEqual('Paul McCartney', beatles.members.filter(name__istartswith='pauL')[0].name)
+        self.assertEqual(1, beatles.members.filter(name__endswith='ney').count())
+        self.assertEqual('Paul McCartney', beatles.members.filter(name__endswith='ney')[0].name)
+        self.assertEqual(1, beatles.members.filter(name__iendswith='Ney').count())
+        self.assertEqual('Paul McCartney', beatles.members.filter(name__iendswith='Ney')[0].name)
+
         self.assertEqual('Paul McCartney', beatles.members.get(name='Paul McCartney').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__exact='Paul McCartney').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__iexact='paul mccartNEY').name)
@@ -73,6 +82,10 @@ class ClusterTest(TestCase):
         self.assertEqual('Paul McCartney', beatles.members.get(name__contains='Cart').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__icontains='carT').name)
         self.assertEqual('Paul McCartney', beatles.members.get(name__in=['Paul McCartney', 'Linda McCartney']).name)
+        self.assertEqual('Paul McCartney', beatles.members.get(name__startswith='Paul').name)
+        self.assertEqual('Paul McCartney', beatles.members.get(name__istartswith='pauL').name)
+        self.assertEqual('Paul McCartney', beatles.members.get(name__endswith='ney').name)
+        self.assertEqual('Paul McCartney', beatles.members.get(name__iendswith='Ney').name)
 
         self.assertRaises(BandMember.DoesNotExist, lambda: beatles.members.get(name='Reginald Dwight'))
         self.assertRaises(BandMember.MultipleObjectsReturned, lambda: beatles.members.get())
@@ -300,6 +313,15 @@ class ClusterTest(TestCase):
 
         self.assertEqual(1, beatles.members.exclude(name__in=['Paul McCartney', 'Linda McCartney']).count())
         self.assertEqual('John Lennon', beatles.members.exclude(name__in=['Paul McCartney', 'Linda McCartney'])[0].name)
+
+        self.assertEqual(1, beatles.members.exclude(name__startswith='Paul').count())
+        self.assertEqual('John Lennon', beatles.members.exclude(name__startswith='Paul').first().name)
+        self.assertEqual(1, beatles.members.exclude(name__istartswith='pauL').count())
+        self.assertEqual('John Lennon', beatles.members.exclude(name__istartswith='pauL').first().name)
+        self.assertEqual(1, beatles.members.exclude(name__endswith='ney').count())
+        self.assertEqual('John Lennon', beatles.members.exclude(name__endswith='ney').first().name)
+        self.assertEqual(1, beatles.members.exclude(name__iendswith='Ney').count())
+        self.assertEqual('John Lennon', beatles.members.exclude(name__iendswith='Ney').first().name)
 
     def test_prefetch_related(self):
         Band.objects.create(name='The Beatles', members=[


### PR DESCRIPTION
Add support for lookup expressions such as `.filter(name__iexact='bob')`, `.filter(score__gt=100)`. The [full set of lookups defined by Django](https://docs.djangoproject.com/en/2.1/ref/models/querysets/#field-lookups) is implemented, although chaining currently isn't supported (either for following relations or things like `date__year__gt=2000`) and there may well be some differences in details such as type casting and timezone handling.