### PR TITLE
Remove Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,10 @@ addons:
 
 matrix:
   include:
-   - env: TOXENV=py27-dj110-sqlite
-     python: 2.7
    - env: TOXENV=py34-dj110-sqlite
      python: 3.4
    - env: TOXENV=py35-dj110-sqlite
      python: 3.5
-   - env: TOXENV=py27-dj111-sqlite
-     python: 2.7
    - env: TOXENV=py35-dj111-sqlite
      python: 3.5
    - env: TOXENV=py36-dj111-sqlite
@@ -38,14 +34,10 @@ matrix:
      python: 3.7
      dist: xenial
      sudo: true
-   - env: TOXENV=py27-dj110-postgres
-     python: 2.7
    - env: TOXENV=py34-dj110-postgres
      python: 3.4
    - env: TOXENV=py35-dj110-postgres
      python: 3.5
-   - env: TOXENV=py27-dj111-postgres
-     python: 2.7
    - env: TOXENV=py35-dj111-postgres
      python: 3.5
    - env: TOXENV=py36-dj111-postgres

--- a/modelcluster/forms.py
+++ b/modelcluster/forms.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import django
 from django.forms import ValidationError
 from django.core.exceptions import NON_FIELD_ERRORS
-from django.utils.six import with_metaclass
 from django.forms.models import (
     BaseModelFormSet, modelformset_factory,
     ModelForm, _get_foreign_key, ModelFormMetaclass, ModelFormOptions
@@ -288,7 +287,7 @@ class ClusterFormMetaclass(ModelFormMetaclass):
         return new_class
 
 
-class ClusterForm(with_metaclass(ClusterFormMetaclass, ModelForm)):
+class ClusterForm(ModelForm, metaclass=ClusterFormMetaclass):
     def __init__(self, data=None, files=None, instance=None, prefix=None, **kwargs):
         super(ClusterForm, self).__init__(data, files, instance=instance, prefix=prefix, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from taggit.managers import TaggableManager
@@ -11,7 +10,6 @@ from modelcluster.fields import ParentalKey, ParentalManyToManyField
 from modelcluster.models import ClusterableModel
 
 
-@python_2_unicode_compatible
 class Band(ClusterableModel):
     name = models.CharField(max_length=255)
 
@@ -19,7 +17,6 @@ class Band(ClusterableModel):
         return self.name
 
 
-@python_2_unicode_compatible
 class BandMember(models.Model):
     band = ParentalKey('Band', related_name='members', on_delete=models.CASCADE)
     name = models.CharField(max_length=255)
@@ -34,7 +31,6 @@ class BandMember(models.Model):
         ]
 
 
-@python_2_unicode_compatible
 class Album(ClusterableModel):
     band = ParentalKey('Band', related_name='albums')
     name = models.CharField(max_length=255)
@@ -50,7 +46,6 @@ class Album(ClusterableModel):
         ordering = ['sort_order']
 
 
-@python_2_unicode_compatible
 class Song(models.Model):
     album = ParentalKey('Album', related_name='songs')
     name = models.CharField(max_length=255)
@@ -69,7 +64,6 @@ class TaggedPlace(TaggedItemBase):
     content_object = ParentalKey('Place', related_name='tagged_items', on_delete=models.CASCADE)
 
 
-@python_2_unicode_compatible
 class Place(ClusterableModel):
     name = models.CharField(max_length=255)
     tags = ClusterTaggableManager(through=TaggedPlace, blank=True)
@@ -91,7 +85,6 @@ class TaggedNonClusterPlace(TaggedItemBase):
     content_object = models.ForeignKey('NonClusterPlace', related_name='tagged_items', on_delete=models.CASCADE)
 
 
-@python_2_unicode_compatible
 class NonClusterPlace(models.Model):
     """
     For backwards compatibility we need ClusterModel to work with
@@ -105,7 +98,6 @@ class NonClusterPlace(models.Model):
         return self.name
 
 
-@python_2_unicode_compatible
 class Dish(models.Model):
     name = models.CharField(max_length=255)
 
@@ -113,7 +105,6 @@ class Dish(models.Model):
         return self.name
 
 
-@python_2_unicode_compatible
 class Wine(models.Model):
     name = models.CharField(max_length=255)
 
@@ -121,7 +112,6 @@ class Wine(models.Model):
         return self.name
 
 
-@python_2_unicode_compatible
 class Chef(models.Model):
     name = models.CharField(max_length=255)
 
@@ -129,7 +119,6 @@ class Chef(models.Model):
         return self.name
 
 
-@python_2_unicode_compatible
 class MenuItem(models.Model):
     restaurant = ParentalKey('Restaurant', related_name='menu_items', on_delete=models.CASCADE)
     dish = models.ForeignKey('Dish', related_name='+', on_delete=models.CASCADE)
@@ -140,7 +129,6 @@ class MenuItem(models.Model):
         return "%s - %f" % (self.dish, self.price)
 
 
-@python_2_unicode_compatible
 class Review(models.Model):
     place = ParentalKey('Place', related_name='reviews', on_delete=models.CASCADE)
     author = models.CharField(max_length=255)
@@ -150,7 +138,6 @@ class Review(models.Model):
         return "%s on %s" % (self.author, self.place.name)
 
 
-@python_2_unicode_compatible
 class Log(ClusterableModel):
     time = models.DateTimeField(blank=True, null=True)
     data = models.CharField(max_length=255)
@@ -159,7 +146,6 @@ class Log(ClusterableModel):
         return "[%s] %s" % (self.time.isoformat(), self.data)
 
 
-@python_2_unicode_compatible
 class Document(ClusterableModel):
     title = models.CharField(max_length=255)
     file = models.FileField(upload_to='documents')
@@ -168,7 +154,6 @@ class Document(ClusterableModel):
         return self.title
 
 
-@python_2_unicode_compatible
 class NewsPaper(ClusterableModel):
     title = models.CharField(max_length=255)
 
@@ -180,7 +165,6 @@ class TaggedArticle(TaggedItemBase):
     content_object = ParentalKey('Article', related_name='tagged_items', on_delete=models.CASCADE)
 
 
-@python_2_unicode_compatible
 class Article(ClusterableModel):
     paper = ParentalKey(NewsPaper, blank=True, null=True, on_delete=models.CASCADE)
     title = models.CharField(max_length=255)
@@ -194,7 +178,6 @@ class Article(ClusterableModel):
         return self.title
 
 
-@python_2_unicode_compatible
 class Author(models.Model):
     name = models.CharField(max_length=255)
 
@@ -205,7 +188,6 @@ class Author(models.Model):
         ordering = ['name']
 
 
-@python_2_unicode_compatible
 class Category(models.Model):
     name = models.CharField(max_length=255)
 
@@ -213,7 +195,6 @@ class Category(models.Model):
         return self.name
 
 
-@python_2_unicode_compatible
 class Gallery(ClusterableModel):
     title = models.CharField(max_length=255)
 

--- a/tests/tests/test_cluster_form.py
+++ b/tests/tests/test_cluster_form.py
@@ -2,8 +2,6 @@ from __future__ import unicode_literals
 
 import unittest
 
-from django.utils.six import text_type
-
 from django.test import TestCase
 from tests.models import Band, BandMember, Album, Restaurant, Article, Author, Document, Gallery, Song
 from modelcluster.forms import ClusterForm
@@ -517,8 +515,8 @@ class ClusterFormTest(TestCase):
 
         form = FormWithWidgetMedia()
 
-        self.assertIn('test.js', text_type(form.media['js']))
-        self.assertIn('test.css', text_type(form.media['css']))
+        self.assertIn('test.js', str(form.media['js']))
+        self.assertIn('test.css', str(form.media['css']))
 
     def test_widgets_with_media_on_child_form(self):
         """
@@ -549,8 +547,8 @@ class ClusterFormTest(TestCase):
 
         form = FormWithWidgetMedia()
 
-        self.assertIn('fancy-text-input.js', text_type(form.media['js']))
-        self.assertIn('fancy-file-uploader.js', text_type(form.media['js']))
+        self.assertIn('fancy-text-input.js', str(form.media['js']))
+        self.assertIn('fancy-file-uploader.js', str(form.media['js']))
 
     def test_is_multipart_on_parent_form(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = 
-    py{27,34,35}-dj110-{sqlite,postgres}
-    py{27,35,36}-dj111-{sqlite,postgres}
+    py{34,35}-dj110-{sqlite,postgres}
+    py{35,36}-dj111-{sqlite,postgres}
     py{34,35,36,37}-dj20-{sqlite,postgres}
     py{35,36,37}-dj21-{sqlite,postgres}
 
@@ -9,7 +9,6 @@ envlist =
 commands=./runtests.py --noinput {posargs}
 
 basepython =
-    py27: python2.7
     py33: python3.3
     py34: python3.4
     py35: python3.5


### PR DESCRIPTION
Necessary for Django 3.0 compatibility (it will drop django.utils.six and the `python_2_unicode_compatible` decorator). I suggest we don't merge this until we're ready to version-bump this package to 5.0.