### PR TITLE
Fix/98 loaddata with parentalmanytomany

### DIFF
--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -375,6 +375,13 @@ def create_deferring_forward_many_to_many_manager(rel, original_manager_cls):
             # 2) if we need to sort it, we can do so without mutating the original
             objs = list(objs)
 
+            if objs and not isinstance(objs[0], rel_model):
+                # assume objs is a list of pks (like when loading data from a
+                # fixture), and allow the orignal manager to handle things
+                original_manager = self.get_original_manager()
+                original_manager.set(objs)
+                return
+
             cluster_related_objects = self._get_cluster_related_objects()
 
             # Clone and sort the 'objs' list, if necessary

--- a/tests/fixtures/parentalmanytomany-to-ordered-model.json
+++ b/tests/fixtures/parentalmanytomany-to-ordered-model.json
@@ -1,0 +1,30 @@
+[
+  {
+    "model": "tests.house",
+    "pk": 1,
+    "fields": {
+      "name": "Weekend home",
+      "address": "1 Homely Drive, Hometown",
+      "owner": null,
+      "main_room": null
+    }
+  },
+  {
+    "model": "tests.house",
+    "pk": 2,
+    "fields": {
+      "name": "Midweek home",
+      "address": "1 Business Park, Worktown",
+      "owner": null,
+      "main_room": null
+    }
+  },
+  {
+    "model": "tests.person",
+    "pk": 1,
+    "fields": {
+      "name": "Mr Two Houses",
+      "houses": [1, 2]
+    }
+  }
+]

--- a/tests/tests/test_fixture_loading.py
+++ b/tests/tests/test_fixture_loading.py
@@ -1,0 +1,18 @@
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+from tests.models import Person
+
+
+class TestLoadsParentalManyToManyToOrderedModel(TestCase):
+
+    fixtures = ["parentalmanytomany-to-ordered-model.json"]
+
+    def test_data_loads_from_fixture(self):
+        """
+        The main test here is that the fixture loads without errors. The code
+        below code then confirms that the relationship was set correctly.
+        """
+        person = Person.objects.get(id=1)
+        self.assertEqual(list(person.houses.values_list("id", flat=True)), [1, 2])


### PR DESCRIPTION
Allows ParentalManyToMany fields values to be respected when using Django's `loaddata` management command.

I'm aware that these changes introduce the possibility of developers accidentally modifying the live database by setting the field value to something other than an iterable of objects. But, I cannot really see another way to make this work, as the parent object is not saved again after the manytomanyfield data is loaded. There does not seem to be a way to tell if the method is being called as a result of `loaddata` or direct manipulation  either, so cannot see a way to make this behaviour conditional. I'm open to ideas on this though :)
