### PR TITLE
Allow formsets to be omitted when ClusterForm.formsets not explicitly passed

### DIFF
--- a/modelcluster/forms.py
+++ b/modelcluster/forms.py
@@ -4,6 +4,7 @@ import django
 from django.forms import ValidationError
 from django.core.exceptions import NON_FIELD_ERRORS
 from django.utils.six import with_metaclass
+from django.forms.formsets import TOTAL_FORM_COUNT
 from django.forms.models import (
     BaseModelFormSet, modelformset_factory,
     ModelForm, _get_foreign_key, ModelFormMetaclass, ModelFormOptions
@@ -288,6 +289,7 @@ class ClusterFormMetaclass(ModelFormMetaclass):
                 formsets[rel_name] = formset
 
             new_class.formsets = formsets
+            new_class._has_explicit_formsets = (opts.formsets is not None or opts.exclude_formsets is not None)
 
         return new_class
 
@@ -304,13 +306,26 @@ class ClusterForm(with_metaclass(ClusterFormMetaclass, ModelForm)):
                 formset_prefix = rel_name
             self.formsets[rel_name] = formset_class(data, files, instance=instance, prefix=formset_prefix)
 
+        if self.is_bound and not self._has_explicit_formsets:
+            # check which formsets have actually been provided as part of the form submission -
+            # if no `formsets` or `exclude_formsets` was specified, we allow them to be omitted
+            # (https://github.com/wagtail/wagtail/issues/5414#issuecomment-567468127).
+            self._posted_formsets = [
+                formset
+                for formset in self.formsets.values()
+                if '%s-%s' % (formset.prefix, TOTAL_FORM_COUNT) in self.data
+            ]
+        else:
+            # expect all defined formsets to be part of the post
+            self._posted_formsets = self.formsets.values()
+
     def as_p(self):
         form_as_p = super(ClusterForm, self).as_p()
         return form_as_p + ''.join([formset.as_p() for formset in self.formsets.values()])
 
     def is_valid(self):
         form_is_valid = super(ClusterForm, self).is_valid()
-        formsets_are_valid = all([formset.is_valid() for formset in self.formsets.values()])
+        formsets_are_valid = all(formset.is_valid() for formset in self._posted_formsets)
         return form_is_valid and formsets_are_valid
 
     def is_multipart(self):
@@ -365,7 +380,7 @@ class ClusterForm(with_metaclass(ClusterFormMetaclass, ModelForm)):
             if commit:
                 instance.save()
 
-        for formset in self.formsets.values():
+        for formset in self._posted_formsets:
             formset.instance = instance
             formset.save(commit=commit)
         return instance
@@ -376,7 +391,7 @@ class ClusterForm(with_metaclass(ClusterFormMetaclass, ModelForm)):
         # Need to recurse over nested formsets so that the form is saved if there are changes
         # to child forms but not the parent
         if self.formsets:
-            for formset in self.formsets.values():
+            for formset in self._posted_formsets:
                 for form in formset.forms:
                     if form.has_changed():
                         return True

--- a/tests/tests/test_cluster_form.py
+++ b/tests/tests/test_cluster_form.py
@@ -2,8 +2,8 @@ from __future__ import unicode_literals
 
 import unittest
 
+from django.core.exceptions import ValidationError
 from django.utils.six import text_type
-
 from django.test import TestCase
 from tests.models import Band, BandMember, Album, Restaurant, Article, Author, Document, Gallery, Song
 from modelcluster.forms import ClusterForm
@@ -216,6 +216,86 @@ class ClusterFormTest(TestCase):
         self.assertEqual('The New Beatles', new_beatles.name)
         self.assertTrue(BandMember.objects.filter(name='George Harrison').exists())
         self.assertFalse(BandMember.objects.filter(name='John Lennon').exists())
+
+    def test_can_omit_formset_from_submission(self):
+        """
+        If no explicit `formsets` parameter has been given, any formsets missing from the
+        submission should be skipped over.
+        https://github.com/wagtail/wagtail/issues/5414#issuecomment-567468127
+        """
+        class BandForm(ClusterForm):
+            class Meta:
+                model = Band
+                fields = ['name']
+
+        john = BandMember(name='John Lennon')
+        paul = BandMember(name='Paul McCartney')
+        abbey_road = Album(name='Abbey Road')
+        beatles = Band(name='The Beatles', members=[john, paul], albums=[abbey_road])
+        beatles.save()
+
+        form = BandForm({
+            'name': "The Beatles",
+
+            'members-TOTAL_FORMS': 3,
+            'members-INITIAL_FORMS': 2,
+            'members-MAX_NUM_FORMS': 1000,
+
+            'members-0-name': john.name,
+            'members-0-DELETE': 'members-0-DELETE',
+            'members-0-id': john.id,
+
+            'members-1-name': paul.name,
+            'members-1-id': paul.id,
+
+            'members-2-name': 'George Harrison',
+            'members-2-id': '',
+        }, instance=beatles)
+        self.assertTrue(form.is_valid())
+        form.save()
+
+        beatles = Band.objects.get(id=beatles.id)
+        self.assertEqual(1, beatles.albums.count())
+        self.assertTrue(BandMember.objects.filter(name='George Harrison').exists())
+        self.assertFalse(BandMember.objects.filter(name='John Lennon').exists())
+
+    def test_cannot_omit_explicit_formset_from_submission(self):
+        """
+        If an explicit `formsets` parameter has been given, formsets missing from a form submission
+        should raise a ValidationError as normal
+        """
+        class BandForm(ClusterForm):
+            class Meta:
+                model = Band
+                fields = ['name']
+                formsets = ['members', 'albums']
+
+        john = BandMember(name='John Lennon')
+        paul = BandMember(name='Paul McCartney')
+        abbey_road = Album(name='Abbey Road')
+        beatles = Band(name='The Beatles', members=[john, paul], albums=[abbey_road])
+        beatles.save()
+
+        form = BandForm({
+            'name': "The Beatles",
+
+            'members-TOTAL_FORMS': 3,
+            'members-INITIAL_FORMS': 2,
+            'members-MAX_NUM_FORMS': 1000,
+
+            'members-0-name': john.name,
+            'members-0-DELETE': 'members-0-DELETE',
+            'members-0-id': john.id,
+
+            'members-1-name': paul.name,
+            'members-1-id': paul.id,
+
+            'members-2-name': 'George Harrison',
+            'members-2-id': '',
+        }, instance=beatles)
+
+        with self.assertRaises(ValidationError):
+            form.is_valid()
 
     def test_saved_items_with_non_db_relation(self):
         class BandForm(ClusterForm):


### PR DESCRIPTION
As per https://github.com/wagtail/wagtail/issues/5414#issuecomment-567468127 - #106 changed the base form class of child forms to ClusterForm, which means that (in the absence of an explicit 'formsets' parameter) they now expect form submissions to contain formsets for every child relation on that model. This breaks some Wagtail setups where child relations exist but are not handled through InlinePanel - e.g tag fields.

Here we modify that behaviour so that, if 'formsets' is not explicitly set on the ClusterForm, it silently skips over any formsets missing from the submission, restoring the previous behaviour.