### PR TITLE
Add Django to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description=open('README.rst').read(),
     python_requires=">=3.5",
     install_requires=[
-        "pytz>=2015.2",
+        "Django>=2.0,<2.3",
     ],
     extras_require={
         'taggit': ['django-taggit>=0.20'],

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ basepython =
 deps =
     taggit0: django-taggit>=0.24,<1
     taggit1: django-taggit>=1
-    pytz>=2014.7
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3


### PR DESCRIPTION
The current setup.py doesn't include Django in its install_requires. This makes it a little harder to do local development on this repository alone, because you have to manually install Django. Additionally, this would make it easier for developers to quickly see which versions of Django are supported by django-modelcluster.

With this change I've also removed pytz from setup.py and tox.ini, as it is automatically installed by Django.