### PR TITLE
Add prefetch_related support to ParentalManyToManyField

### DIFF
--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.core import checks
-from django.db import IntegrityError, router
+from django.db import IntegrityError, connections, router
 from django.db.models import CASCADE
 from django.db.models.fields.related import ForeignKey, ManyToManyField
 from django.utils.functional import cached_property
@@ -271,14 +271,19 @@ class ParentalKey(ForeignKey):
 
 
 def create_deferring_forward_many_to_many_manager(rel, original_manager_cls):
-    relation_name = rel.field.name
+    rel_field = rel.field
+    relation_name = rel_field.name
+    query_field_name = rel_field.related_query_name()
+    source_field_name = rel_field.m2m_field_name()
     rel_model = rel.model
     superclass = rel_model._default_manager.__class__
+    rel_through = rel.through
 
     class DeferringManyRelatedManager(superclass):
         def __init__(self, instance=None):
             super(DeferringManyRelatedManager, self).__init__()
             self.model = rel_model
+            self.through = rel_through
             self.instance = instance
 
         def get_original_manager(self):
@@ -316,6 +321,46 @@ def create_deferring_forward_many_to_many_manager(rel, original_manager_cls):
                     return rel_model.objects.none()
 
             return FakeQuerySet(rel_model, results)
+
+        def get_prefetch_queryset(self, instances, queryset=None):
+            # Derived from Django's ManyRelatedManager.get_prefetch_queryset.
+            if queryset is None:
+                queryset = super().get_queryset()
+
+            queryset._add_hints(instance=instances[0])
+            queryset = queryset.using(queryset._db or self._db)
+
+            query = {'%s__in' % query_field_name: instances}
+            queryset = queryset._next_is_sticky().filter(**query)
+
+            fk = self.through._meta.get_field(source_field_name)
+            join_table = fk.model._meta.db_table
+
+            connection = connections[queryset.db]
+            qn = connection.ops.quote_name
+
+            queryset = queryset.extra(select={
+                '_prefetch_related_val_%s' % f.attname:
+                '%s.%s' % (qn(join_table), qn(f.column)) for f in fk.local_related_fields})
+
+            return (
+                queryset,
+                lambda result: tuple(
+                    getattr(result, '_prefetch_related_val_%s' % f.attname)
+                    for f in fk.local_related_fields
+                ),
+                lambda inst: tuple(
+                    f.get_db_prep_value(getattr(inst, f.attname), connection)
+                    for f in fk.foreign_related_fields
+                ),
+                False,
+                relation_name,
+                False,
+            )
+
+        def _apply_rel_filters(self, queryset):
+            # Required for get_prefetch_queryset.
+            return queryset._next_is_sticky()
 
         def get_object_list(self):
             """

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -766,6 +766,7 @@ class ParentalM2MTest(TestCase):
 
 class ParentalManyToManyPrefetchTests(TestCase):
     def setUp(self):
+        # Create 10 articles with 10 authors each.
         authors = Author.objects.bulk_create(
             Author(id=i, name=str(i)) for i in range(10)
         )
@@ -805,6 +806,21 @@ class ParentalManyToManyPrefetchTests(TestCase):
             )
 
         self.assertEqual(len(names), 50)
+
+    def test_prefetch_from_fake_queryset(self):
+        article = Article(title='Article with related articles')
+        article.related_articles = list(Article.objects.all())
+
+        with self.assertNumQueries(10):
+            names = self.get_author_names(article.related_articles.all())
+
+        with self.assertNumQueries(1):
+            prefetched_names = self.get_author_names(
+                article.related_articles.prefetch_related('authors')
+            )
+
+        self.assertEqual(names, prefetched_names)
+
 
 class PrefetchRelatedTest(TestCase):
     def test_fakequeryset_prefetch_related(self):


### PR DESCRIPTION
This commit adds support for prefetch_related on ParentalManyToManyFields. Consider for example these models:

```py
class Author(models.Model):
    ...

class Article(ClusterableModel):
    authors = ParentalManyToManyField(Author)
```

With this change, you can create a query like this:

```
articles = Article.objects.prefetch_related('authors')
```

and then subsequent references to article authors won't invoke additional database queries.

This implementation is modeled after [the current implementation](https://github.com/django/django/blob/a34cb5a6d408203f4fbdb364fc9768c026eda224/django/db/models/fields/related_descriptors.py#L907) of Django's `ManyRelatedManager.get_prefetch_queryset`.

Closes #101.

I've done limited testing on this with Wagtail 2.3 (see https://github.com/wagtail/wagtail/issues/4784), but it'd be great to get others testing against more recent versions.