### PR TITLE
Make modelcluster work with django-taggit 1.3+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,13 @@ matrix:
      python: 3.5
    - env: TOXENV=py36-dj22-sqlite-taggit1
      python: 3.6
+   - env: TOXENV=py36-dj22-sqlite-taggit13
+     python: 3.6
    - env: TOXENV=py37-dj22-sqlite-taggit0
+     python: 3.7
+   - env: TOXENV=py37-dj22-sqlite-taggit1
+     python: 3.7
+   - env: TOXENV=py37-dj22-sqlite-taggit13
      python: 3.7
    - env: TOXENV=py35-dj20-postgres-taggit0
      python: 3.5
@@ -26,18 +32,24 @@ matrix:
      python: 3.7
    - env: TOXENV=py35-dj22-postgres-taggit1
      python: 3.5
+   - env: TOXENV=py35-dj22-postgres-taggit13
+     python: 3.5
    - env: TOXENV=py36-dj22-postgres-taggit1
+     python: 3.6
+   - env: TOXENV=py36-dj22-postgres-taggit13
      python: 3.6
    - env: TOXENV=py37-dj22-postgres-taggit1
      python: 3.7
-   - env: TOXENV=py37-dj22stable-postgres-taggit1
+   - env: TOXENV=py37-dj22-postgres-taggit13
      python: 3.7
-   - env: TOXENV=py37-djmaster-postgres-taggit1
+   - env: TOXENV=py37-dj22stable-postgres-taggit13
+     python: 3.7
+   - env: TOXENV=py37-djmaster-postgres-taggit13
      python: 3.7
   allow_failures:
     # allow failures against Django git master and 2.2.x stable
-    - env: TOXENV=py37-dj22stable-postgres-taggit1
-    - env: TOXENV=py37-djmaster-postgres-taggit1
+    - env: TOXENV=py37-dj22stable-postgres-taggit13
+    - env: TOXENV=py37-djmaster-postgres-taggit13
 
 install:
   - pip install tox

--- a/modelcluster/contrib/taggit.py
+++ b/modelcluster/contrib/taggit.py
@@ -41,7 +41,10 @@ class _ClusterTaggableManager(_TaggableManager):
 
     @require_instance_manager
     def add(self, *tags):
-        tag_objs = self._to_tag_model_instances(tags)
+        if TAGGIT_VERSION >= (1, 3, 0):
+            tag_objs = self._to_tag_model_instances(tags, {})
+        else:
+            tag_objs = self._to_tag_model_instances(tags)
 
         # Now write these to the relation
         tagged_item_manager = self.get_tagged_item_manager()

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{35,36,37}-dj20-{sqlite,postgres}-taggit{0,1}
-    py{35,36,37}-dj21-{sqlite,postgres}-taggit{0,1}
-    py{35,36,37}-dj22-{sqlite,postgres}-taggit{0,1}
+    py{35,36,37}-dj20-{sqlite,postgres}-taggit{0,1,13}
+    py{35,36,37}-dj21-{sqlite,postgres}-taggit{0,1,13}
+    py{35,36,37}-dj22-{sqlite,postgres}-taggit{0,1,13}
 
 [testenv]
 commands=./runtests.py --noinput {posargs}
@@ -14,7 +14,8 @@ basepython =
 
 deps =
     taggit0: django-taggit>=0.24,<1
-    taggit1: django-taggit>=1
+    taggit1: django-taggit>=1,<1.3
+    taggit13: django-taggit>=1.3
     pytz>=2014.7
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2


### PR DESCRIPTION
This is a PR that aims to make django-modelcluster compatible with the latest version of django-taggit (1.3.0). In this PR I have:

- Added a version check to make sure `_to_tag_model_instances` are called with compatible arguments
- Introduced a new tox tag for taggit ("taggit13")
- Updated the travis test suite to run explicit tests against the new taggit version