### PR TITLE
Allow formset form override in ClusterForm

### DIFF
--- a/modelcluster/forms.py
+++ b/modelcluster/forms.py
@@ -261,6 +261,7 @@ class ClusterFormMetaclass(ModelFormMetaclass):
 
                 kwargs = {
                     'extra': cls.extra_form_count,
+                    'form': cls.child_form(),
                     'formfield_callback': formfield_callback,
                     'fk_name': rel.field.name,
                     'widgets': widgets
@@ -273,7 +274,7 @@ class ClusterFormMetaclass(ModelFormMetaclass):
                 except AttributeError:
                     pass
 
-                formset = childformset_factory(opts.model, rel.field.model, form=cls.child_form(), **kwargs)
+                formset = childformset_factory(opts.model, rel.field.model, **kwargs)
                 formsets[rel_name] = formset
 
             new_class.formsets = formsets

--- a/tests/tests/test_cluster_form.py
+++ b/tests/tests/test_cluster_form.py
@@ -154,6 +154,21 @@ class ClusterFormTest(TestCase):
         self.assertNotIn('release_date', form.formsets['albums'].forms[0].fields)
         self.assertEqual(Textarea, type(form.formsets['albums'].forms[0]['name'].field.widget))
 
+    def test_custom_formset_form(self):
+        class AlbumForm(ClusterForm):
+            pass
+
+        class BandForm(ClusterForm):
+            class Meta:
+                model = Band
+                formsets = {
+                    'albums': {'fields': ['name'], 'form': AlbumForm}
+                }
+                fields = ['name']
+
+        form = BandForm()
+        self.assertTrue(isinstance(form.formsets.get("albums").forms[0], AlbumForm))
+
     def test_formfield_callback(self):
 
         def formfield_for_dbfield(db_field, **kwargs):


### PR DESCRIPTION
The form for any formset defined in ClusterForm was fixed in the metaclass.

This allows overriding the form class in the formset definition so we don't have to extend the metaclass just for that.

Closes #125 