### PR TITLE
Fix behavior of ParentalKeys and prefetch_related() supplied with a lookup queryset

### DIFF
--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -69,7 +69,10 @@ def create_deferring_foreign_related_manager(related, original_manager_cls):
         def _apply_rel_filters(self, queryset):
             # Implemented as empty for compatibility sake
             # But there is probably a better implementation of this function
-            return queryset._next_is_sticky()
+            #
+            # NOTE: _apply_rel_filters() must return a copy of the queryset
+            # to work correctly with prefetch
+            return queryset._next_is_sticky().all()
 
         def get_prefetch_queryset(self, instances, queryset=None):
             if queryset is None:


### PR DESCRIPTION
`RelatedManager._apply_rel_filters()` must return a copy of the queryset for Django's [prefetch_one_level()](https://github.com/django/django/blob/f4ac167119e8897c398527c392ed117326496652/django/db/models/query.py#L1896
) to work correctly. Otherwise the result cache of the singular Prefetch lookup queryset is overridden and incorrect prefetched results are returned.

I've included a test that should fail if this fix is not in place.