### PR TITLE
Restore all ptr_id attributes with multi table inheritance

### DIFF
--- a/modelcluster/models.py
+++ b/modelcluster/models.py
@@ -56,11 +56,16 @@ def get_serializable_data_for_fields(model):
 
 def model_from_serializable_data(model, data, check_fks=True, strict_fks=False):
     pk_field = model._meta.pk
-    # If model is a child via multitable inheritance, use parent's pk
+    kwargs = {}
+
+    # If model is a child via multitable inheritance, we need to set ptr_id fields all the way up
+    # to the main PK field, as Django won't populate these for us automatically.
     while pk_field.remote_field and pk_field.remote_field.parent_link:
+        kwargs[pk_field.attname] = data['pk']
         pk_field = pk_field.remote_field.model._meta.pk
 
-    kwargs = {pk_field.attname: data['pk']}
+    kwargs[pk_field.attname] = data['pk']
+
     for field_name, field_value in data.items():
         try:
             field = model._meta.get_field(field_name)

--- a/tests/tests/test_serialize.py
+++ b/tests/tests/test_serialize.py
@@ -7,8 +7,8 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.utils import timezone
 
-from tests.models import Band, BandMember, Album, Restaurant, Dish, MenuItem, Chef, Wine, \
-    Review, Log, Document, Article, Author, Category
+from tests.models import Band, BandMember, Album, Place, Restaurant, SeafoodRestaurant, Dish, \
+    MenuItem, Chef, Wine, Review, Log, Document, Article, Author, Category
 
 
 class SerializeTest(TestCase):
@@ -111,6 +111,15 @@ class SerializeTest(TestCase):
         self.assertEqual(fat_duck.name, "The Fat Duck")
         self.assertEqual(fat_duck.serves_hot_dogs, False)
         self.assertEqual(fat_duck.reviews.all()[0].author, "Michael Winner")
+
+    def test_deserialize_with_second_level_multi_table_inheritance(self):
+        oyster_club = SeafoodRestaurant.from_json('{"pk": 43, "name": "The Oyster Club"}')
+        self.assertEqual(oyster_club.id, 43)
+        self.assertEqual(oyster_club.restaurant_ptr_id, 43)
+        self.assertEqual(oyster_club.place_ptr_id, 43)
+        self.assertEqual(oyster_club.restaurant_ptr.__class__, Restaurant)
+        self.assertEqual(oyster_club.place_ptr.__class__, Place)
+        self.assertEqual(oyster_club.name, "The Oyster Club")
 
     def test_dangling_foreign_keys(self):
         heston_blumenthal = Chef.objects.create(name="Heston Blumenthal")


### PR DESCRIPTION
Closes #135

Using `DATABASE_NAME=":memory:" ./shell.py` as the example again.

```pycon
Python 3.8.6 (default, Oct 10 2020, 00:15:38)
[Clang 12.0.0 (clang-1200.0.32.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> from django.core.management import call_command
>>> call_command("migrate")
Operations to perform:
  Apply all migrations: contenttypes, taggit, tests
Running migrations:
  Applying contenttypes.0001_initial... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying taggit.0001_initial... OK
  Applying taggit.0002_auto_20150616_2121... OK
  Applying taggit.0003_taggeditem_add_unique_index... OK
  Applying tests.0001_initial... OK
  Applying tests.0002_add_m2m_models... OK
  Applying tests.0003_gallery_galleryimage... OK
  Applying tests.0004_auto_20170406_1734... OK
  Applying tests.0005_article_fk_to_newspaper... OK
  Applying tests.0006_auto_20171109_0614... OK
  Applying tests.0007_add_bandmember_favourite_restaurant... OK
  Applying tests.0008_prefetch_related_tests... OK
  Applying tests.0009_article_related_articles... OK
  Applying tests.0010_song... OK
>>> from tests.models import Dish, MenuItem, Restaurant, SeafoodRestaurant
>>> oyster_club = SeafoodRestaurant.objects.create(name="The Oyster Club")
>>> dish = Dish.objects.create(name="Food")
>>> MenuItem.objects.create(restaurant=oyster_club, dish=dish, price=1)
<MenuItem: Food - 1.000000>
```

On this branch, restoring the object sets the attributes needed for certain querysets:

```
>>> oyster_club = SeafoodRestaurant.from_json('{"pk": 1, "name": "The Oyster Club"}')
>>> Restaurant.objects.filter(menu_items__restaurant=oyster_club)
<QuerySet [<Restaurant: The Oyster Club>]>
>>> oyster_club.restaurant_ptr_id
1
>>> oyster_club.restaurant_ptr
<Restaurant: The Oyster Club>
>>> oyster_club.place_ptr_id
1
>>> oyster_club.place_ptr
<Place: The Oyster Club>
```