### PR TITLE
Use formset error data to test for formset errors

### DIFF
--- a/tests/tests/test_formset.py
+++ b/tests/tests/test_formset.py
@@ -276,7 +276,7 @@ class ChildFormsetTest(TestCase):
             'form-2-id': '',
         })
         self.assertFalse(band_members_formset.is_valid())
-        self.assertEqual(band_members_formset.non_form_errors()[0], "Please submit 2 or fewer forms.")
+        self.assertEqual(band_members_formset.non_form_errors().as_data()[0].code, "too_many_forms")
 
     def test_max_num_pass_validation(self):
         BandMembersFormset = childformset_factory(Band, BandMember, max_num=2, validate_max=True)
@@ -319,7 +319,7 @@ class ChildFormsetTest(TestCase):
             'form-0-id': '',
         })
         self.assertFalse(band_members_formset.is_valid())
-        self.assertEqual(band_members_formset.non_form_errors()[0], "Please submit 2 or more forms.")
+        self.assertEqual(band_members_formset.non_form_errors().as_data()[0].code, "too_few_forms")
 
     def test_min_num_pass_validation(self):
         BandMembersFormset = childformset_factory(Band, BandMember, min_num=2, validate_min=True)


### PR DESCRIPTION
Noticed a test failure in my previous PR for Django master: https://travis-ci.org/github/wagtail/django-modelcluster/jobs/738638351

Which is due to: https://github.com/django/django/commit/848770dd2c5dec6c805d67f470eb936f38b9421d#diff-a15f77935ea5615b828e3b11360d485f0c1dede839f6e5faf2e41430db90e927

I've updated the test to something which works across Django versions. Sadly formsets don't have the `.has_error()` method which forms do - so this feels like the next best thing.