### PR TITLE
Allow ClusterForm formset names to differ from the relation name

### DIFF
--- a/modelcluster/forms.py
+++ b/modelcluster/forms.py
@@ -264,7 +264,8 @@ class ClusterFormMetaclass(ModelFormMetaclass):
                     'form': cls.child_form(),
                     'formfield_callback': formfield_callback,
                     'fk_name': rel.field.name,
-                    'widgets': widgets
+                    'widgets': widgets,
+                    'formset_name': rel_name
                 }
 
                 # see if opts.formsets looks like a dict; if so, allow the value
@@ -274,8 +275,9 @@ class ClusterFormMetaclass(ModelFormMetaclass):
                 except AttributeError:
                     pass
 
+                formset_name = kwargs.pop('formset_name')
                 formset = childformset_factory(opts.model, rel.field.model, **kwargs)
-                formsets[rel_name] = formset
+                formsets[formset_name] = formset
 
             new_class.formsets = formsets
             new_class._has_explicit_formsets = (opts.formsets is not None or opts.exclude_formsets is not None)

--- a/tests/tests/test_cluster_form.py
+++ b/tests/tests/test_cluster_form.py
@@ -169,6 +169,31 @@ class ClusterFormTest(TestCase):
         form = BandForm()
         self.assertTrue(isinstance(form.formsets.get("albums").forms[0], AlbumForm))
 
+    def test_alternative_formset_name(self):
+        """Support specifying a formset_name that differs from the relation"""
+        class BandForm(ClusterForm):
+            class Meta:
+                model = Band
+                formsets = {
+                    'albums': {'fields': ['name'], 'formset_name': 'records'}
+                }
+                fields = ['name']
+
+        form = BandForm({
+            'name': "The Beatles",
+
+            'records-TOTAL_FORMS': 1,
+            'records-INITIAL_FORMS': 0,
+            'records-MAX_NUM_FORMS': 1000,
+
+            'records-0-name': 'Please Please Me',
+            'records-0-id': '',
+        })
+
+        self.assertTrue(form.is_valid())
+        result = form.save(commit=False)
+        self.assertEqual(result.albums.first().name, 'Please Please Me')
+
     def test_formfield_callback(self):
 
         def formfield_for_dbfield(db_field, **kwargs):


### PR DESCRIPTION
This is part of the fix for https://github.com/wagtail/wagtail/issues/7343 / https://github.com/wagtail/wagtail/issues/7476 - it allows us to change the related_name of the 'comments' relation while still keeping the formset named 'comments' (so that formdata in unit tests doesn't need to change).