### PR TITLE
Use assertRaisesRegex instead of assertRaisesRegexp for Python 3.11 compatibility.

### DIFF
--- a/tests/tests/test_tag.py
+++ b/tests/tests/test_tag.py
@@ -158,7 +158,7 @@ class TagTest(TestCase):
     def test_integers(self):
         """Adding an integer as a tag should raise a ValueError"""
         mission_burrito = Place(name='Mission Burrito')
-        with self.assertRaisesRegexp(ValueError, (
+        with self.assertRaisesRegex(ValueError, (
                 r"Cannot add 1 \(<(type|class) 'int'>\). "
                 r"Expected <class 'django.db.models.base.ModelBase'> or str.")):
             mission_burrito.tags.add(1)


### PR DESCRIPTION
The deprecated aliases have been removed in https://github.com/python/cpython/pull/28268