### PR TITLE
Add iterable classes and `values()` implementation to `FakeQuerySet`

### DIFF
--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -446,13 +446,14 @@ class FakeQuerySet(object):
         return clone
 
     def get(self, **kwargs):
-        results = self.filter(**kwargs)
-        result_count = results.count()
+        clone = self.filter(**kwargs)
+        result_count = clone.count()
 
         if result_count == 0:
             raise self.model.DoesNotExist("%s matching query does not exist." % self.model._meta.object_name)
         elif result_count == 1:
-            return results[0]
+            for result in clone:
+                return result
         else:
             raise self.model.MultipleObjectsReturned(
                 "get() returned more than one %s -- it returned %s!" % (self.model._meta.object_name, result_count)
@@ -465,12 +466,14 @@ class FakeQuerySet(object):
         return bool(self.results)
 
     def first(self):
-        if self.results:
-            return self.results[0]
+        for result in self:
+            return result
 
     def last(self):
         if self.results:
-            return self.results[-1]
+            clone = self.get_clone(results=reversed(self.results))
+            for result in clone:
+                return result
 
     def select_related(self, *args):
         # has no meaningful effect on non-db querysets

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -373,14 +373,12 @@ class ModelIterable(FakeQuerySetIterable):
 
 class DictIterable(FakeQuerySetIterable):
     def __iter__(self):
+        field_names = self.queryset.dict_fields or [field.name for field in self.queryset.model._meta.fields]
         for obj in self.queryset.results:
-            if self.queryset.dict_fields:
-                yield {
-                    field_name: extract_field_value(obj, field_name, pk_only=True, suppress_fielddoesnotexist=True)
-                    for field_name in self.queryset.dict_fields
-                }
-            else:
-                yield obj.__dict__
+            yield {
+                field_name: extract_field_value(obj, field_name, pk_only=True, suppress_fielddoesnotexist=True)
+                for field_name in field_names
+            }
 
 
 class ValuesListIterable(FakeQuerySetIterable):

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -376,7 +376,7 @@ class DictIterable(FakeQuerySetIterable):
         for obj in self.queryset.results:
             if self.queryset.dict_fields:
                 yield {
-                    field_name: extract_field_value(obj, field_name, suppress_fielddoesnotexist=True)
+                    field_name: extract_field_value(obj, field_name, pk_only=True, suppress_fielddoesnotexist=True)
                     for field_name in self.queryset.dict_fields
                 }
             else:
@@ -387,14 +387,14 @@ class ValuesListIterable(FakeQuerySetIterable):
     def __iter__(self):
         field_names = self.queryset.tuple_fields or [field.name for field in self.queryset.model._meta.fields]
         for obj in self.queryset.results:
-            yield tuple([extract_field_value(obj, field_name, suppress_fielddoesnotexist=True) for field_name in field_names])
+            yield tuple([extract_field_value(obj, field_name, pk_only=True, suppress_fielddoesnotexist=True) for field_name in field_names])
 
 
 class FlatValuesListIterable(FakeQuerySetIterable):
     def __iter__(self):
         field_name = self.queryset.tuple_fields[0]
         for obj in self.queryset.results:
-            yield extract_field_value(obj, field_name, suppress_fielddoesnotexist=True)
+            yield extract_field_value(obj, field_name, pk_only=True, suppress_fielddoesnotexist=True)
 
 
 class FakeQuerySet(object):

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -483,7 +483,13 @@ class FakeQuerySet(object):
         prefetch_related_objects(self.results, *args)
         return self
 
+    def only(self, *args):
+        # has no meaningful effect on non-db querysets
+        return self
 
+    def defer(self, *args):
+        # has no meaningful effect on non-db querysets
+        return self
 
     def values(self, *fields):
         clone = self.get_clone()

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -16,6 +16,16 @@ from tests.models import Band, BandMember, Chef, Feature, Place, Restaurant, Sea
 
 
 class ClusterTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.gordon_ramsay = Chef.objects.create(name="Gordon Ramsay")
+        cls.strawberry_fields = Restaurant.objects.create(name="Strawberry Fields", proprietor=cls.gordon_ramsay)
+
+        cls.marco_pierre_white = Chef.objects.create(name="Marco Pierre White")
+        cls.the_yellow_submarine = Restaurant.objects.create(name="The Yellow Submarine", proprietor=cls.marco_pierre_white)
+
     def test_can_create_cluster(self):
         beatles = Band(name='The Beatles')
 
@@ -333,10 +343,7 @@ class ClusterTest(TestCase):
         self.assertEqual(3, beatles.members.filter(band=also_beatles).count())
 
     def test_queryset_filtering_on_models_with_inheritance(self):
-        strawberry_fields = Restaurant.objects.create(name='Strawberry Fields')
-        the_yellow_submarine = SeafoodRestaurant.objects.create(name='The Yellow Submarine')
-
-        john = BandMember(name='John Lennon', favourite_restaurant=strawberry_fields)
+        john = BandMember(name='John Lennon', favourite_restaurant=self.strawberry_fields)
         ringo = BandMember(name='Ringo Starr', favourite_restaurant=Restaurant.objects.get(name='The Yellow Submarine'))
 
         beatles = Band(name='The Beatles', members=[john, ringo])
@@ -547,17 +554,11 @@ class ClusterTest(TestCase):
         )
 
     def test_queryset_filtering_accross_foreignkeys(self):
-        gordon = Chef.objects.create(name="Gordon Ramsay")
-        strawberry_fields = Restaurant.objects.create(name="Strawberry Fields", proprietor=gordon)
-
-        marco = Chef.objects.create(name="Marco Pierre White")
-        the_yellow_submarine = Restaurant.objects.create(name="The Yellow Submarine", proprietor=marco)
-
         band = Band(
             name="The Beatles",
             members=[
-                BandMember(name="John Lennon", favourite_restaurant=strawberry_fields),
-                BandMember(name="Ringo Starr", favourite_restaurant=the_yellow_submarine)
+                BandMember(name="John Lennon", favourite_restaurant=self.strawberry_fields),
+                BandMember(name="Ringo Starr", favourite_restaurant=self.the_yellow_submarine)
             ],
         )
 
@@ -630,17 +631,11 @@ class ClusterTest(TestCase):
         )
 
     def test_ordering_accross_foreignkeys(self):
-        gordon = Chef.objects.create(name="Gordon Ramsay")
-        strawberry_fields = Restaurant.objects.create(name="Strawberry Fields", proprietor=gordon)
-
-        marco = Chef.objects.create(name="Marco Pierre White")
-        the_yellow_submarine = Restaurant.objects.create(name="The Yellow Submarine", proprietor=marco)
-
         band = Band(
             name="The Beatles",
             members=[
-                BandMember(name="John Lennon", favourite_restaurant=strawberry_fields),
-                BandMember(name="Ringo Starr", favourite_restaurant=the_yellow_submarine)
+                BandMember(name="John Lennon", favourite_restaurant=self.strawberry_fields),
+                BandMember(name="Ringo Starr", favourite_restaurant=self.the_yellow_submarine),
             ],
         )
 

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -220,7 +220,7 @@ class ClusterTest(TestCase):
         # Not specifying 'fields' should return dictionaries with all field values
         self.assertEqual(
             [
-                beatles.members.get(name='Paul McCartney').__dict__
+                {"id": None, "band": None, "name": "Paul McCartney", "favourite_restaurant": self.the_yellow_submarine.id}
             ],
             list(beatles.members.filter(name='Paul McCartney').values())
         )

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -144,18 +144,20 @@ class ClusterTest(TestCase):
 
     def test_values_list(self):
         beatles = Band(
-            name='The Beatles',
+            name="The Beatles",
             members=[
-                BandMember(name='John Lennon'),
-                BandMember(name='Paul McCartney'),
-            ]
+                BandMember(name="John Lennon", favourite_restaurant=self.strawberry_fields),
+                BandMember(name="Paul McCartney", favourite_restaurant=self.the_yellow_submarine),
+                BandMember(name="George Harrison"),
+                BandMember(name="Ringo Starr"),
+            ],
         )
 
         # Not specifying 'fields' should return a tuple of all field values
         self.assertEqual(
             [
                 # ID, band, name, favourite_restaurant
-                (None, beatles, 'Paul McCartney', None)
+                (None, beatles, 'Paul McCartney', self.the_yellow_submarine)
             ],
             list(beatles.members.filter(name='Paul McCartney').values_list())
         )
@@ -164,6 +166,17 @@ class ClusterTest(TestCase):
 
         # Specifying 'fields' should return a tuple of just those field values
         self.assertEqual([NAME_ONLY_TUPLE], list(beatles.members.filter(name='Paul McCartney').values_list('name')))
+
+        # Items in 'fields' can span relationships using '__'
+        self.assertEqual(
+            list(beatles.members.all().values_list('name', 'favourite_restaurant__proprietor__name')),
+            [
+                ("John Lennon", "Gordon Ramsay"),
+                ("Paul McCartney", "Marco Pierre White"),
+                ("George Harrison", None),
+                ("Ringo Starr", None)
+            ]
+        )
 
         # get() should return a tuple if used after values_list()
         self.assertEqual(NAME_ONLY_TUPLE, beatles.members.filter(name='Paul McCartney').values_list('name').get())
@@ -182,11 +195,13 @@ class ClusterTest(TestCase):
 
     def test_values(self):
         beatles = Band(
-            name='The Beatles',
+            name="The Beatles",
             members=[
-                BandMember(name='John Lennon'),
-                BandMember(name='Paul McCartney'),
-            ]
+                BandMember(name="John Lennon", favourite_restaurant=self.strawberry_fields),
+                BandMember(name="Paul McCartney", favourite_restaurant=self.the_yellow_submarine),
+                BandMember(name="George Harrison"),
+                BandMember(name="Ringo Starr"),
+            ],
         )
 
         # Not specifying 'fields' should return dictionaries with all field values
@@ -201,6 +216,17 @@ class ClusterTest(TestCase):
 
         # Specifying 'fields' should return a dictionary of just those field values
         self.assertEqual([NAME_ONLY_DICT], list(beatles.members.filter(name='Paul McCartney').values('name')))
+
+        # Items in 'fields' can span relationships using '__'
+        self.assertEqual(
+            list(beatles.members.all().values('name', 'favourite_restaurant__proprietor__name')),
+            [
+                {"name": "John Lennon", "favourite_restaurant__proprietor__name": "Gordon Ramsay"},
+                {"name": "Paul McCartney", "favourite_restaurant__proprietor__name": "Marco Pierre White"},
+                {"name": "George Harrison", "favourite_restaurant__proprietor__name": None},
+                {"name": "Ringo Starr", "favourite_restaurant__proprietor__name": None},
+            ]
+        )
 
         # get() should return a dict if used after values()
         self.assertEqual(NAME_ONLY_DICT, beatles.members.filter(name='Paul McCartney').values('name').get())

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -170,6 +170,40 @@ class ClusterTest(TestCase):
         # Filtering or ordering after using values_list() should not raise an error
         beatles.members.values_list("name").filter(name__contains="n").order_by("name")
 
+    def test_values(self):
+        beatles = Band(
+            name='The Beatles',
+            members=[
+                BandMember(name='John Lennon'),
+                BandMember(name='Paul McCartney'),
+            ]
+        )
+
+        # Not specifying 'fields' should return dictionaries with all field values
+        self.assertEqual(
+            [
+                beatles.members.get(name='Paul McCartney').__dict__
+            ],
+            list(beatles.members.filter(name='Paul McCartney').values())
+        )
+
+        NAME_ONLY_DICT = {"name": "Paul McCartney"}
+
+        # Specifying 'fields' should return a dictionary of just those field values
+        self.assertEqual([NAME_ONLY_DICT], list(beatles.members.filter(name='Paul McCartney').values('name')))
+
+        # get() should return a dict if used after values()
+        self.assertEqual(NAME_ONLY_DICT, beatles.members.filter(name='Paul McCartney').values('name').get())
+
+        # first() should return a dict if used after values_list()
+        self.assertEqual(NAME_ONLY_DICT, beatles.members.filter(name='Paul McCartney').values('name').first())
+
+        # last() should return a dict if used after values_list()
+        self.assertEqual(NAME_ONLY_DICT, beatles.members.filter(name='Paul McCartney').values('name').last())
+
+        # Filtering or ordering after using values() should not raise an error
+        beatles.members.values("name").filter(name__contains="n").order_by("name")
+
     def test_related_manager_assignment_ops(self):
         beatles = Band(name='The Beatles')
         john = BandMember(name='John Lennon')

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -356,7 +356,7 @@ class ClusterTest(TestCase):
 
         # queried instance is more specific
         self.assertEqual(
-            list(beatles.members.filter(favourite_restaurant=the_yellow_submarine)),
+            list(beatles.members.filter(favourite_restaurant=self.the_yellow_submarine)),
             [ringo]
         )
 
@@ -605,11 +605,11 @@ class ClusterTest(TestCase):
         )
         # Using an exact proprietor comparisson
         self.assertEqual(
-            tuple(band.members.filter(favourite_restaurant__proprietor=gordon)),
+            tuple(band.members.filter(favourite_restaurant__proprietor=self.gordon_ramsay)),
             (band.members.get(name="John Lennon"),)
         )
         self.assertEqual(
-            tuple(band.members.filter(favourite_restaurant__proprietor=marco)),
+            tuple(band.members.filter(favourite_restaurant__proprietor=self.marco_pierre_white)),
             (band.members.get(name="Ringo Starr"),)
         )
 


### PR DESCRIPTION
This PR adds the following:
- Django-like 'iterable' classes that return values in the expected format - allowing us to keep the actual 'evaluation' (not really evaluation, but you know what I mean!) 'lazy' 
- A values() implementation