### PR TITLE
Avoid accessing live queryset on unsaved instances (Django 4.1 fix)

### DIFF
--- a/modelcluster/contrib/taggit.py
+++ b/modelcluster/contrib/taggit.py
@@ -29,7 +29,7 @@ class _ClusterTaggableManager(_TaggableManager):
             # (which probably means it's being invoked within a prefetch_related operation);
             # this means that we don't have to deal with uncommitted models/tags, and can just
             # use the standard taggit handler
-            return super(_ClusterTaggableManager, self).get_queryset(extra_filters)
+            return super().get_queryset(extra_filters)
         else:
             # FIXME: we ought to have some way of querying the tagged item manager about whether
             # it has uncommitted changes, and return a real queryset (using the original taggit logic)
@@ -75,7 +75,7 @@ class _ClusterTaggableManager(_TaggableManager):
         # to ensure that the correct set of m2m_changed signals is fired, and our reimplementation here
         # doesn't fire them at all (which makes logical sense, because the whole point of this module is
         # that the add/remove/set/clear operations don't write to the database).
-        return super(_ClusterTaggableManager, self).set(*args, clear=True)
+        return super().set(*args, clear=True)
 
     @require_instance_manager
     def clear(self):

--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -62,7 +62,11 @@ def create_deferring_foreign_related_manager(related, original_manager_cls):
             try:
                 results = self.instance._cluster_related_objects[relation_name]
             except (AttributeError, KeyError):
-                return self.get_live_queryset()
+                if self.instance.pk is None:
+                    # use an empty fake queryset if the instance is unsaved
+                    results = []
+                else:
+                    return self.get_live_queryset()
 
             return FakeQuerySet(related.related_model, results)
 
@@ -105,7 +109,10 @@ def create_deferring_foreign_related_manager(related, original_manager_cls):
             try:
                 object_list = cluster_related_objects[relation_name]
             except KeyError:
-                object_list = list(self.get_live_queryset())
+                if self.instance.pk is None:
+                    object_list = []
+                else:
+                    object_list = list(self.get_live_queryset())
                 cluster_related_objects[relation_name] = object_list
 
             return object_list

--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -29,7 +29,7 @@ def create_deferring_foreign_related_manager(related, original_manager_cls):
 
     class DeferringRelatedManager(superclass):
         def __init__(self, instance):
-            super(DeferringRelatedManager, self).__init__()
+            super().__init__()
             self.model = rel_model
             self.instance = instance
 
@@ -77,7 +77,7 @@ def create_deferring_foreign_related_manager(related, original_manager_cls):
         def get_prefetch_queryset(self, instances, queryset=None):
             if queryset is None:
                 db = self._db or router.db_for_read(self.model, instance=instances[0])
-                queryset = super(DeferringRelatedManager, self).get_queryset().using(db)
+                queryset = super().get_queryset().using(db)
 
             rel_obj_attr = rel_field.get_local_related_value
             instance_attr = rel_field.get_foreign_related_value
@@ -236,12 +236,12 @@ class ParentalKey(ForeignKey):
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('on_delete', CASCADE)
-        super(ParentalKey, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def check(self, **kwargs):
         from modelcluster.models import ClusterableModel
 
-        errors = super(ParentalKey, self).check(**kwargs)
+        errors = super().check(**kwargs)
 
         # Check that the destination model is a subclass of ClusterableModel.
         # If self.rel.to is a string at this point, it means that Django has been unable
@@ -284,7 +284,7 @@ def create_deferring_forward_many_to_many_manager(rel, original_manager_cls):
 
     class DeferringManyRelatedManager(superclass):
         def __init__(self, instance=None):
-            super(DeferringManyRelatedManager, self).__init__()
+            super().__init__()
             self.model = rel_model
             self.through = rel_through
             self.instance = instance
@@ -506,7 +506,7 @@ class ParentalManyToManyField(ManyToManyField):
         # https://github.com/django/django/blob/6157cd6da1b27716e8f3d1ed692a6e33d970ae46/django/db/models/fields/related.py#L1538
         # So, we'll let the original contribute_to_class do its thing, and then overwrite
         # the accessor...
-        super(ParentalManyToManyField, self).contribute_to_class(cls, name, **kwargs)
+        super().contribute_to_class(cls, name, **kwargs)
         setattr(cls, self.name, self.related_accessor_class(self.remote_field))
 
     def value_from_object(self, obj):

--- a/modelcluster/forms.py
+++ b/modelcluster/forms.py
@@ -84,13 +84,13 @@ class BaseChildFormSet(BaseTransientModelFormSet):
         if queryset is None:
             queryset = getattr(self.instance, self.rel_name).all()
 
-        super(BaseChildFormSet, self).__init__(data, files, queryset=queryset, **kwargs)
+        super().__init__(data, files, queryset=queryset, **kwargs)
 
     def save(self, commit=True):
         # The base ModelFormSet's save(commit=False) will populate the lists
         # self.changed_objects, self.deleted_objects and self.new_objects;
         # use these to perform the appropriate updates on the relation's manager.
-        saved_instances = super(BaseChildFormSet, self).save(commit=False)
+        saved_instances = super().save(commit=False)
 
         manager = getattr(self.instance, self.rel_name)
 
@@ -121,7 +121,7 @@ class BaseChildFormSet(BaseTransientModelFormSet):
 
     def clean(self, *args, **kwargs):
         self.validate_unique()
-        return super(BaseChildFormSet, self).clean(*args, **kwargs)
+        return super().clean(*args, **kwargs)
 
     def validate_unique(self):
         '''This clean method will check for unique_together condition'''
@@ -207,7 +207,7 @@ def childformset_factory(
 
 class ClusterFormOptions(ModelFormOptions):
     def __init__(self, options=None):
-        super(ClusterFormOptions, self).__init__(options=options)
+        super().__init__(options=options)
         self.formsets = getattr(options, 'formsets', None)
         self.exclude_formsets = getattr(options, 'exclude_formsets', None)
 
@@ -231,7 +231,7 @@ class ClusterFormMetaclass(ModelFormMetaclass):
         # BAD METACLASS NO BISCUIT.
         formfield_callback = attrs.get('formfield_callback')
 
-        new_class = super(ClusterFormMetaclass, cls).__new__(cls, name, bases, attrs)
+        new_class = super().__new__(cls, name, bases, attrs)
         if not parents:
             return new_class
 
@@ -287,7 +287,7 @@ class ClusterFormMetaclass(ModelFormMetaclass):
 
 class ClusterForm(ModelForm, metaclass=ClusterFormMetaclass):
     def __init__(self, data=None, files=None, instance=None, prefix=None, **kwargs):
-        super(ClusterForm, self).__init__(data, files, instance=instance, prefix=prefix, **kwargs)
+        super().__init__(data, files, instance=instance, prefix=prefix, **kwargs)
 
         self.formsets = {}
         for rel_name, formset_class in self.__class__.formsets.items():
@@ -311,23 +311,23 @@ class ClusterForm(ModelForm, metaclass=ClusterFormMetaclass):
             self._posted_formsets = self.formsets.values()
 
     def as_p(self):
-        form_as_p = super(ClusterForm, self).as_p()
+        form_as_p = super().as_p()
         return form_as_p + ''.join([formset.as_p() for formset in self.formsets.values()])
 
     def is_valid(self):
-        form_is_valid = super(ClusterForm, self).is_valid()
+        form_is_valid = super().is_valid()
         formsets_are_valid = all(formset.is_valid() for formset in self._posted_formsets)
         return form_is_valid and formsets_are_valid
 
     def is_multipart(self):
         return (
-            super(ClusterForm, self).is_multipart()
+            super().is_multipart()
             or any(formset.is_multipart() for formset in self.formsets.values())
         )
 
     @property
     def media(self):
-        media = super(ClusterForm, self).media
+        media = super().media
         for formset in self.formsets.values():
             media = media + formset.media
         return media
@@ -347,7 +347,7 @@ class ClusterForm(ModelForm, metaclass=ClusterFormMetaclass):
                 save_m2m_now = True
                 break
 
-        instance = super(ClusterForm, self).save(commit=(commit and not save_m2m_now))
+        instance = super().save(commit=(commit and not save_m2m_now))
 
         # The M2M-like fields designed for use with ClusterForm (currently
         # ParentalManyToManyField and ClusterTaggableManager) will manage their own in-memory

--- a/modelcluster/models.py
+++ b/modelcluster/models.py
@@ -168,11 +168,11 @@ class ClusterableModel(models.Model):
                 if rel_name in kwargs:
                     relation_assignments[rel_name] = kwargs_for_super.pop(rel_name)
 
-            super(ClusterableModel, self).__init__(*args, **kwargs_for_super)
+            super().__init__(*args, **kwargs_for_super)
             for (field_name, related_instances) in relation_assignments.items():
                 setattr(self, field_name, related_instances)
         else:
-            super(ClusterableModel, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
 
     def save(self, **kwargs):
         """
@@ -198,7 +198,7 @@ class ClusterableModel(models.Model):
                 else:
                     real_update_fields.append(field)
 
-        super(ClusterableModel, self).save(update_fields=real_update_fields, **kwargs)
+        super().save(update_fields=real_update_fields, **kwargs)
 
         for relation in relations_to_commit:
             getattr(self, relation).commit()


### PR DESCRIPTION
In cases where a DeferringRelatedManager was read on an in-memory instance before being written to, it was accessing the real manager on an unsaved instance. This was tolerated up to Django 4.0, but it's a hard fail as of https://github.com/django/django/commit/7ba6ebe9149ae38257d70100e8bfbfd0da189862.