### PR TITLE
Add inherit_kwargs attribute to ClusterForm child formsets

### DIFF
--- a/modelcluster/forms.py
+++ b/modelcluster/forms.py
@@ -8,6 +8,7 @@ from django.forms.models import (
     ModelForm, _get_foreign_key, ModelFormMetaclass, ModelFormOptions
 )
 from django.db.models.fields.related import ForeignObjectRel
+from django.utils.html import format_html_join
 
 
 from modelcluster.models import get_all_child_relations
@@ -312,7 +313,7 @@ class ClusterForm(ModelForm, metaclass=ClusterFormMetaclass):
 
     def as_p(self):
         form_as_p = super().as_p()
-        return form_as_p + ''.join([formset.as_p() for formset in self.formsets.values()])
+        return form_as_p + format_html_join('', '{}', [(formset.as_p(),) for formset in self.formsets.values()])
 
     def is_valid(self):
         form_is_valid = super().is_valid()

--- a/modelcluster/forms.py
+++ b/modelcluster/forms.py
@@ -74,6 +74,8 @@ def transientmodelformset_factory(model, formset=BaseTransientModelFormSet, **kw
 
 
 class BaseChildFormSet(BaseTransientModelFormSet):
+    inherit_kwargs = None
+
     def __init__(self, data=None, files=None, instance=None, queryset=None, **kwargs):
         if instance is None:
             self.instance = self.fk.remote_field.model()
@@ -171,7 +173,8 @@ def childformset_factory(
     parent_model, model, form=ModelForm,
     formset=BaseChildFormSet, fk_name=None, fields=None, exclude=None,
     extra=3, can_order=False, can_delete=True, max_num=None, validate_max=False,
-    formfield_callback=None, widgets=None, min_num=None, validate_min=False
+    formfield_callback=None, widgets=None, min_num=None, validate_min=False,
+    inherit_kwargs=None,
 ):
 
     fk = _get_foreign_key(parent_model, model, fk_name=fk_name)
@@ -203,6 +206,11 @@ def childformset_factory(
     }
     FormSet = transientmodelformset_factory(model, **kwargs)
     FormSet.fk = fk
+
+    # A list of keyword argument names that should be passed on from ClusterForm's constructor
+    # to child forms in this formset
+    FormSet.inherit_kwargs = inherit_kwargs
+
     return FormSet
 
 
@@ -296,7 +304,15 @@ class ClusterForm(ModelForm, metaclass=ClusterFormMetaclass):
                 formset_prefix = "%s-%s" % (prefix, rel_name)
             else:
                 formset_prefix = rel_name
-            self.formsets[rel_name] = formset_class(data, files, instance=instance, prefix=formset_prefix)
+
+            child_form_kwargs = {}
+            if formset_class.inherit_kwargs:
+                for kwarg_name in formset_class.inherit_kwargs:
+                    child_form_kwargs[kwarg_name] = kwargs.get(kwarg_name)
+
+            self.formsets[rel_name] = formset_class(
+                data, files, instance=instance, prefix=formset_prefix, form_kwargs=child_form_kwargs
+            )
 
         if self.is_bound and not self._has_explicit_formsets:
             # check which formsets have actually been provided as part of the form submission -

--- a/tests/tests/test_cluster_form.py
+++ b/tests/tests/test_cluster_form.py
@@ -9,6 +9,7 @@ from tests.models import Band, BandMember, Album, Restaurant, Article, Author, D
 from modelcluster.forms import ClusterForm
 from django.forms import Textarea, CharField
 from django.forms.widgets import TextInput, FileInput
+from django.utils.safestring import SafeString
 
 import datetime
 
@@ -30,7 +31,9 @@ class ClusterFormTest(TestCase):
         form = BandForm(instance=beatles)
 
         self.assertEqual(5, len(form.formsets['members'].forms))
-        self.assertTrue('albums' in form.as_p())
+        form_html = form.as_p()
+        self.assertIsInstance(form_html, SafeString)
+        self.assertInHTML('<label for="id_albums-0-name">Name:</label>', form_html)
 
     def test_empty_cluster_form(self):
         class BandForm(ClusterForm):

--- a/tests/tests/test_cluster_form.py
+++ b/tests/tests/test_cluster_form.py
@@ -158,6 +158,46 @@ class ClusterFormTest(TestCase):
         self.assertNotIn('release_date', form.formsets['albums'].forms[0].fields)
         self.assertEqual(Textarea, type(form.formsets['albums'].forms[0]['name'].field.widget))
 
+    def test_without_kwarg_inheritance(self):
+        # by default, kwargs passed to the ClusterForm do not propagate to child forms
+        class BandForm(ClusterForm):
+            class Meta:
+                model = Band
+                formsets = {
+                    'members': {'fields': ['name']}
+                }
+                fields = ['name']
+
+        form = BandForm(label_suffix="!!!:")
+        form_html = form.as_p()
+        # band name field should have label_suffix applied
+        self.assertInHTML('<label for="id_name">Name!!!:</label>', form_html)
+        # but this should not propagate to member form fields
+        self.assertInHTML('<label for="id_members-0-name">Name!!!:</label>', form_html, count=0)
+
+    def test_with_kwarg_inheritance(self):
+        # inherit_kwargs should allow kwargs passed to the ClusterForm to propagate to child forms
+        class BandForm(ClusterForm):
+            class Meta:
+                model = Band
+                formsets = {
+                    'members': {'fields': ['name'], 'inherit_kwargs': ['label_suffix']}
+                }
+                fields = ['name']
+
+        form = BandForm(label_suffix="!!!:")
+        form_html = form.as_p()
+        # band name field should have label_suffix applied
+        self.assertInHTML('<label for="id_name">Name!!!:</label>', form_html)
+        # and this should propagate to member form fields too
+        self.assertInHTML('<label for="id_members-0-name">Name!!!:</label>', form_html)
+
+        # the form should still work without a label_suffix kwarg
+        form = BandForm()
+        form_html = form.as_p()
+        self.assertInHTML('<label for="id_name">Name:</label>', form_html)
+        self.assertInHTML('<label for="id_members-0-name">Name:</label>', form_html)
+
     def test_custom_formset_form(self):
         class AlbumForm(ClusterForm):
             pass


### PR DESCRIPTION
This specifies a list of keyword argument names; when any of these are passed to the parent ClusterForm's constructor, they will also be passed on to the child forms of that formset (via the formset's form_kwargs keyword argument).

(This is needed for Wagtail's edit handler refactoring: we want to be able to construct a form class without first binding the edit handler to a request, as this will allow us to re-use that form class globally across all requests. However, CommentPanel relies on the old pattern of having the request object available so that it can construct a one-time formset class with the current user embedded into it as a class-level property. To avoid this, we want to be able to construct a formset class that isn't tied to the user object, and instead have it receive the user on instantiation, which we're currently passing to the top-level WagtailAdminModelForm as the `for_user` kwarg introduced in https://github.com/wagtail/wagtail/pull/8060. This means we need some new plumbing to pass that on to the child forms.