### PR TITLE
Run to_python() when deserializing PK value

### DIFF
--- a/modelcluster/models.py
+++ b/modelcluster/models.py
@@ -64,7 +64,7 @@ def model_from_serializable_data(model, data, check_fks=True, strict_fks=False):
         kwargs[pk_field.attname] = data['pk']
         pk_field = pk_field.remote_field.model._meta.pk
 
-    kwargs[pk_field.attname] = data['pk']
+    kwargs[pk_field.attname] = pk_field.to_python(data['pk'])
 
     for field_name, field_value in data.items():
         try:


### PR DESCRIPTION
This is required for non-numeric PKs, for example UUIDs.