### PR TITLE
Update queryset.py to solve bug: 'FakeQuerySet' object has no attribute '_prefetch_related_lookups'

### DIFF
--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -481,6 +481,9 @@ class FakeQuerySet(object):
         prefetch_related_objects(self.results, *args)
         return self
 
+    def _prefetch_related_lookups():
+        return []
+    
     def only(self, *args):
         # has no meaningful effect on non-db querysets
         return self


### PR DESCRIPTION
Resolve bug: 
'FakeQuerySet' object has no attribute '_prefetch_related_lookups'