### PR TITLE
Add support for Django 4.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,58 +12,67 @@ jobs:
       matrix:
         include:
           - python: "3.7"
-            django: "Django>=2.2,<2.3"
-            taggit: "django-taggit>=1,<1.3"
+            django: "Django>=3.2,<4.0"
+            taggit: "django-taggit>=2.0"
             database: "sqlite3"
-            psycopg: "psycopg2>=2.6,<2.9"
+            psycopg: "psycopg2>=2.6"
             experimental: false
           - python: "3.8"
-            django: "Django>=3.0,<3.1"
-            taggit: "django-taggit>=1.3,<2.0"
-            database: "postgresql"
-            psycopg: "psycopg2>=2.6,<2.9"
-            experimental: false
-          - python: "3.9"
-            django: "Django>=3.1,<3.2"
-            taggit: "django-taggit>=1.3,<2.0"
-            database: "sqlite3"
-            psycopg: "psycopg2>=2.6,<2.9"
-            experimental: false
-          - python: "3.10"
-            django: "Django>=3.2,<3.3"
+            django: "Django>=3.2"
             taggit: "django-taggit>=2.0"
             database: "postgresql"
             psycopg: "psycopg2>=2.6"
+            experimental: false
+          - python: "3.9"
+            django: "Django>=3.2"
+            taggit: "django-taggit>=2.0"
+            database: "sqlite3"
+            psycopg: "psycopg2>=2.9"
+            experimental: false
+          - python: "3.10"
+            django: "Django>=3.2.9,<4.0"
+            taggit: "django-taggit>=2.1.0"
+            database: "postgresql"
+            psycopg: "psycopg2>=2.9.2"
             experimental: false
           - python: "3.10"
             django: "Django>=4.0,<4.1"
-            taggit: "django-taggit>=2.0"
+            taggit: "django-taggit>=2.1.0"
             database: "postgresql"
-            psycopg: "psycopg2>=2.6"
+            psycopg: "psycopg2>=2.9.2"
             experimental: false
           - python: "3.10"
-            django: "git+https://github.com/django/django.git@stable/4.0.x#egg=Django"
-            taggit: "django-taggit>=2.0"
+            django: "Django>=4.1,<4.2"
+            taggit: "django-taggit>=2.1.0"
+            database: "postgresql"
+            psycopg: "psycopg2>=2.9.2"
+            experimental: false
+          - python: "3.10"
+            django: "git+https://github.com/django/django.git@stable/4.1.x#egg=Django"
+            taggit: "django-taggit>=2.1.0"
             database: "sqlite3"
-            psycopg: "psycopg2>=2.6"
+            psycopg: "psycopg2>=2.9.2"
             experimental: true
           - python: "3.10"
             django: "git+https://github.com/django/django.git@main#egg=Django"
-            taggit: "django-taggit>=2.0"
+            taggit: "django-taggit>=2.1.0"
             database: "postgresql"
-            psycopg: "psycopg2>=2.6"
+            psycopg: "psycopg2>=2.9.2"
             experimental: true
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:11.16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies

--- a/modelcluster/models.py
+++ b/modelcluster/models.py
@@ -23,9 +23,9 @@ def get_field_value(field, model):
         if isinstance(value, datetime.datetime) and settings.USE_TZ:
             if timezone.is_naive(value):
                 default_timezone = timezone.get_default_timezone()
-                value = timezone.make_aware(value, default_timezone).astimezone(timezone.utc)
+                value = timezone.make_aware(value, default_timezone).astimezone(datetime.timezone.utc)
             # convert to UTC
-            value = timezone.localtime(value, timezone.utc)
+            value = timezone.localtime(value, datetime.timezone.utc)
 
         if is_protected_type(value):
             return value

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,11 @@ setup(
     long_description=open('README.rst').read(),
     python_requires=">=3.7",
     install_requires=[
-        "pytz>=2015.2",
-        "django>=2.2",
+        "pytz>=2022.4",
+        "django>=3.2",
     ],
     extras_require={
-        'taggit': ['django-taggit>=0.20'],
+        'taggit': ['django-taggit>=2.0'],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tox.ini
+++ b/tox.ini
@@ -1,37 +1,25 @@
 [tox]
 envlist =
-    py{35,36,37}-dj{20,21}-{sqlite,postgres}-taggit{0,1}
-    py{35,36,37}-dj22-{sqlite,postgres}-taggit{0,1,13}
-    py{36,37,38}-dj{30,31,32}-{sqlite,postgres}-taggit13
-    py{37,38,39,310}-dj{32,40}-{sqlite,postgres}-taggit2
+    py{37,38,39,310}-dj{32,40,41}-{sqlite,postgres}-taggit2
 
 [testenv]
 commands=./runtests.py --noinput {posargs}
 
 basepython =
-    py35: python3.5
-    py36: python3.6
     py37: python3.7
     py38: python3.8
     py39: python3.8
     py310: python3.10
 
 deps =
-    taggit0: django-taggit>=0.24,<1
-    taggit1: django-taggit>=1,<1.3
-    taggit13: django-taggit>=1.3,<2.0
-    taggit2: django-taggit>=2
-    pytz>=2014.7
-    dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1,<2.2
-    dj22: Django>=2.2,<2.3
-    dj30: Django>=3.0,<3.1
-    dj31: Django>=3.1,<3.2
+    taggit2: django-taggit>=2.0
+    pytz>=2022.4
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
+    dj41: Django>=4.1,<4.2
     dj40stable: git+https://github.com/django/django.git@stable/4.0.x#egg=Django
     djmaster: git+https://github.com/django/django.git@master#egg=Django
-    postgres: psycopg2>=2.6
+    postgres: psycopg2>=2.9
 
 setenv =
     postgres: DATABASE_ENGINE=django.db.backends.postgresql_psycopg2


### PR DESCRIPTION
The only actual code change required so far was to remove deprecated uses of `django.utils.timezone.utc` (to be removed in Django 5), and replace with `datetime.timezone.utc` from the standard library (available since Python 3.7). 

The rest of the changes are with the test configurations. I've got the tests mostly passing* but have some questions:

- Is `tox` still used or should this be removed in favor of Github actions/workflows? 
- Should the Github workflow test every possible combination of supported Python & Django versions? The previous configuration did not, so I did not add additional combinations to the test matrix. It also wasn't clear to me when to use sqlite3 vs postgresql as the database (Python 3.7 and 3.9 only test against sqlite3, all other versions of Python use postgresql).

I've done my best to find the minimum versions that are mutually compatible. E.g. `psycopg2>=2.9.2` was the first version to support Python 3.10, PostgreSQL v11 is the oldest version still supported by Django 4.1, etc.

`*` I do see a [test failure](https://github.com/GreenLightGo/django-modelcluster/actions/runs/3257101497/jobs/5348150642) when testing against django.git@main, but have not had a chance to investigate yet.

Also, I had to update the Github actions versions to address deprecations.

FYI, django-taggit doesn't "officially" support Django 4.1 but it appears this is [mostly cosmetic](https://github.com/jazzband/django-taggit/pull/815/files) and does not require a new release.