### PR TITLE
Avoid unnecessary call to localtime for timestamps already in UTC

### DIFF
--- a/modelcluster/models.py
+++ b/modelcluster/models.py
@@ -24,8 +24,9 @@ def get_field_value(field, model):
             if timezone.is_naive(value):
                 default_timezone = timezone.get_default_timezone()
                 value = timezone.make_aware(value, default_timezone).astimezone(timezone.utc)
-            # convert to UTC
-            value = timezone.localtime(value, timezone.utc)
+            else:
+                # convert to UTC
+                value = timezone.localtime(value, timezone.utc)
 
         if is_protected_type(value):
             return value


### PR DESCRIPTION
I hope I haven't overseen anything, but this call only makes sense for aware values, since naive values already get converted with `.astimezone(timezone.utc)` above.

Stumbled over this, because I've based some changes of https://github.com/wagtail/wagtail/pull/9590 on the serialization handling of django-modelcluster.