### PR TITLE
Fix crash when doing implicit exact lookup on a field with the same name as a lookup

### DIFF
--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -350,7 +350,7 @@ FILTER_EXPRESSION_TOKENS = {
 def _build_test_function_from_filter(model, key_clauses, val):
     # Translate a filter kwarg rule (e.g. foo__bar__exact=123) into a function which can
     # take a model instance and return a boolean indicating whether it passes the rule
-    if key_clauses[-1] in FILTER_EXPRESSION_TOKENS:
+    if key_clauses[-1] in FILTER_EXPRESSION_TOKENS and len(key_clauses) > 1:
         # the last clause indicates the type of test
         constructor = FILTER_EXPRESSION_TOKENS[key_clauses.pop()]
     else:


### PR DESCRIPTION
Fixes #171.

Will add tests later.