### PR TITLE
Remove Travis CI badge from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-.. image:: https://travis-ci.org/wagtail/django-modelcluster.svg?branch=master
-    :target: https://travis-ci.org/wagtail/django-modelcluster
-
 django-modelcluster
 ===================
 


### PR DESCRIPTION
The Travis badge in the README now 404s and shows a broken link icon:

![image](https://github.com/wagtail/django-modelcluster/assets/654645/d656366a-0ad4-4812-ba26-bbb347956cff)

Project CI now runs on GitHub Actions. The Travis CI configuration was removed in 2021 in commit 73ed0ef1d440c05020fe0951c7afe076c44acd88.