### PR TITLE
Implement prefetching for ClusterTaggableManager

### DIFF
--- a/modelcluster/contrib/taggit.py
+++ b/modelcluster/contrib/taggit.py
@@ -24,23 +24,75 @@ class _ClusterTaggableManager(_TaggableManager):
         return getattr(self.instance, rel_name)
 
     def get_queryset(self, extra_filters=None):
-        if self.instance is None:
-            # this manager is not associated with a specific model instance
-            # (which probably means it's being invoked within a prefetch_related operation);
-            # this means that we don't have to deal with uncommitted models/tags, and can just
-            # use the standard taggit handler
-            return super().get_queryset(extra_filters)
-        else:
-            # FIXME: we ought to have some way of querying the tagged item manager about whether
-            # it has uncommitted changes, and return a real queryset (using the original taggit logic)
-            # if not
-            return FakeQuerySet(
-                self.through.tag_model(),
-                [tagged_item.tag for tagged_item in self.get_tagged_item_manager().all()]
-            )
+        if self.instance is not None:
+            tagged_item_manager = self.get_tagged_item_manager()
+
+            # If we're already managing tags in memory for this instance,
+            # we want to return those uncommitted changes. This shouldn't
+            # require a request to the database.
+            if tagged_item_manager.is_deferring:
+                return FakeQuerySet(
+                    self.through.tag_model(),
+                    [tagged_item.tag for tagged_item in tagged_item_manager.all()],
+                )
+
+            # If we don't have any uncommitted changes for this instance,
+            # we'd ideally like to use the default taggit logic. There's one
+            # case that we need to handle specially, which is the ability to
+            # query tags on an unsaved model instance, for example:
+            #
+            #   class TaggedPlace(TaggedItemBase):
+            #      content_object = ParentalKey(
+            #          "Place",
+            #          related_name="tagged_items",
+            #          on_delete=models.CASCADE,
+            #      )
+            #
+            #   class Place(ClusterableModel):
+            #       tags = ClusterTaggableManager(
+            #           through=TaggedPlace,
+            #           blank=True,
+            #       )
+            #
+            #   instance = Place()
+            #   instance.tags.count()
+            #
+            # Under the hood this call invokes this get_queryset method with an
+            # unsaved self.instance, which would trigger this query using the
+            # default taggit logic:
+            #
+            #   TaggedPlace.objects.filter(content_object=Place())
+            #
+            # This works on Django < 5.0, returning an empty list as expected.
+            # But as of Django 5.0, passing unsaved model instances to related
+            # filters is no longer allowed, see
+            # https://code.djangoproject.com/ticket/31486.
+            #
+            # To handle this case we return an empty tag list since there won't
+            # be any existing tags in the database for an unsaved instance.
+            elif self.instance.pk is None:
+                return FakeQuerySet(self.through.tag_model(), [])
+
+        # If we've reached this point then either this manager isn't associated
+        # with a specific model, which probably means it's being invoked within
+        # a prefetch_related operation:
+        #
+        #  Place.objects.prefetch_related("tags")
+        #
+        # or we're fetching tags for a model instance that doesn't have any
+        # uncommitted tag changes in memory:
+        #
+        #   place = Place.objects.first()
+        #   place.tags.all()
+        #
+        # In these cases we can fallback to the default taggit manager behavior
+        # which will fetch the tags from the database.
+        return super().get_queryset(extra_filters)
 
     @require_instance_manager
     def add(self, *tags):
+        self._remove_prefetched_objects()
+
         if TAGGIT_VERSION >= (1, 3, 0):
             tag_objs = self._to_tag_model_instances(tags, {})
         else:
@@ -56,6 +108,8 @@ class _ClusterTaggableManager(_TaggableManager):
 
     @require_instance_manager
     def remove(self, *tags):
+        self._remove_prefetched_objects()
+
         tagged_item_manager = self.get_tagged_item_manager()
         tagged_items = [
             tagged_item for tagged_item in tagged_item_manager.all()
@@ -75,10 +129,13 @@ class _ClusterTaggableManager(_TaggableManager):
         # to ensure that the correct set of m2m_changed signals is fired, and our reimplementation here
         # doesn't fire them at all (which makes logical sense, because the whole point of this module is
         # that the add/remove/set/clear operations don't write to the database).
+        #
+        # super().set() already calls self._remove_prefetched_objects() so we don't need to do so here.
         return super().set(*args, clear=True)
 
     @require_instance_manager
     def clear(self):
+        self._remove_prefetched_objects()
         self.get_tagged_item_manager().clear()
 
 

--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -33,6 +33,12 @@ def create_deferring_foreign_related_manager(related, original_manager_cls):
             self.model = rel_model
             self.instance = instance
 
+        @property
+        def is_deferring(self):
+            return relation_name in getattr(
+                self.instance, '_cluster_related_objects', {}
+            )
+
         def _get_cluster_related_objects(self):
             # Helper to retrieve the instance's _cluster_related_objects dict,
             # creating it if it does not already exist


### PR DESCRIPTION
This commit implements prefetching for ClusterTaggableManager so that prefetch_related works properly:

```py
class TaggedPlace(TaggedItemBase):
    content_object = ParentalKey(
        "Place",
        related_name="tagged_items",
        on_delete=models.CASCADE,
    )

class Place(ClusterableModel):
    tags = ClusterTaggableManager(
        through=TaggedPlace,
        blank=True,
    )

places = Place.objects.prefetch_related("tags").all()
for place in places:
    place.tags.all()
```

Currently the above code functions properly but does not actually leverage the prefetching; each call to `place.tags.all()` re-queries the database for each place's tags, instead of using the list previously fetched with the `prefetch_related("tags")`.

This commit properly implements prefetch_related to avoid those duplicate queries.

To test, run tox.

This change requires a bit of complexity due to a change in Django 5.0+ (which is tested under tox but not currently tested in GitHub Actions): As documented in https://code.djangoproject.com/ticket/31486, it's no longer possible to pass unsaved model instances to related filters, preventing calls like:

```py
TaggedPlace.objects.filter(content_object=Place())
```

This requires some special handling to continue to support querying tags on unsaved model instances:

```py
place = Place()
place.tags.count()
```

Please see comments in taggit.py for additional detail.

Closes #38, and may also address https://github.com/wagtail/wagtail/issues/6044.