### PR TITLE
Add support for randomized ordering of fakequeryset

### DIFF
--- a/modelcluster/utils.py
+++ b/modelcluster/utils.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models import ManyToManyField, ManyToManyRel
+from random import random
 
 REL_DELIMETER = "__"
 
@@ -128,6 +129,8 @@ def sort_by_fields(items, fields):
         def get_sort_value(item):
             # Use a tuple of (v is not None, v) as the key, to ensure that None sorts before other values,
             # as comparing directly with None breaks on python3
+            if key == "?":  # Random ordering
+                return (True, random())
             value = extract_field_value(item, key, pk_only=True, suppress_fielddoesnotexist=True)
             return (value is not None, value)
 

--- a/modelcluster/utils.py
+++ b/modelcluster/utils.py
@@ -1,7 +1,7 @@
 from functools import lru_cache
 from django.core.exceptions import FieldDoesNotExist
 from django.db.models import ManyToManyField, ManyToManyRel
-from random import random
+import random
 
 REL_DELIMETER = "__"
 
@@ -120,6 +120,10 @@ def sort_by_fields(items, fields):
     # To get the desired behaviour, we need to order by keys in reverse order
     # See: https://docs.python.org/2/howto/sorting.html#sort-stability-and-complex-sorts
     for key in reversed(fields):
+        if key == '?':
+            random.shuffle(items)
+            continue
+
         # Check if this key has been reversed
         reverse = False
         if key[0] == '-':
@@ -129,8 +133,6 @@ def sort_by_fields(items, fields):
         def get_sort_value(item):
             # Use a tuple of (v is not None, v) as the key, to ensure that None sorts before other values,
             # as comparing directly with None breaks on python3
-            if key == "?":  # Random ordering
-                return (True, random())
             value = extract_field_value(item, key, pk_only=True, suppress_fielddoesnotexist=True)
             return (value is not None, value)
 

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -726,6 +726,20 @@ class ClusterTest(TestCase):
             )
         )
 
+    def test_random_ordering(self):
+        beatles = Band(name='The Beatles', members=[
+            BandMember(name='John Lennon'),
+            BandMember(name='Paul McCartney'),
+            BandMember(name='George Harrison'),
+            BandMember(name='Ringo Starr'),
+        ])
+
+        # Check that all members are returned
+        self.assertCountEqual(
+            beatles.members.order_by('?'),
+            [beatles.members.get(name=name) for name in ['John Lennon', 'Paul McCartney', 'George Harrison', 'Ringo Starr']]
+        )
+    
     def test_filtering_via_manytomany_raises_exception(self):
         bay_window = Feature.objects.create(name="Bay window", desirability=6)
         underfloor_heating = Feature.objects.create(name="Underfloor heading", desirability=10)


### PR DESCRIPTION
Fixes #111 

This PR randomizes the queryset by using `random.random()` values as the key during sorting of the results.