### PR TITLE
Add distinct method to FakeQuerySet

### DIFF
--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import datetime
 import re
 
-from django.db import NotSupportedError, connection
 from django.db.models import Model, prefetch_related_objects
 
 from modelcluster.utils import extract_field_value, get_model_field, sort_by_fields
@@ -519,15 +518,12 @@ class FakeQuerySet(object):
         return clone
     
     def distinct(self, *fields):
-        if fields and connection.vendor != 'postgresql':
-            raise NotSupportedError("DISTINCT ON fields is not supported by this database backend")
-
         unique_results = []
         if not fields:
             fields = [field.name for field in self.model._meta.fields if not field.primary_key]
         seen_keys = set()
         for result in self.results:
-            key = '$$$'.join([str(extract_field_value(result, field)) for field in fields])
+            key = tuple(str(extract_field_value(result, field)) for field in fields)
             if key not in seen_keys:
                 seen_keys.add(key)
                 unique_results.append(result)

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -2,10 +2,9 @@ from __future__ import unicode_literals
 
 import datetime
 import itertools
-from unittest.mock import patch
 
 from django.test import TestCase
-from django.db import IntegrityError, NotSupportedError, connection
+from django.db import IntegrityError
 from django.db.models import Prefetch
 
 from modelcluster.models import get_all_child_relations
@@ -813,19 +812,11 @@ class ClusterTest(TestCase):
             Album(name='With The Beatles', sort_order=2),
             Album(name='Abbey Road', sort_order=2),
         ])
-        
-        for vendor in ['sqlite', 'mysql', 'oracle']:
-            with patch.object(connection, 'vendor', vendor):
-                with self.assertRaises(NotSupportedError):
-                    beatles.albums.order_by('sort_order').distinct('sort_order')
-        
-        # patch db.connection.vendor to pass the vendor check
-        with patch.object(connection, 'vendor', 'postgresql'):
-            albums = [album.name for album in beatles.albums.order_by('sort_order').distinct('sort_order')]
-            self.assertEqual(['Please Please Me', 'With The Beatles'], albums)
+        albums = [album.name for album in beatles.albums.order_by('sort_order').distinct('sort_order')]
+        self.assertEqual(['Please Please Me', 'With The Beatles'], albums)
 
-            albums = [album.name for album in beatles.albums.order_by('sort_order').distinct('name')]
-            self.assertEqual(['Please Please Me', 'With The Beatles', 'Abbey Road'], albums)
+        albums = [album.name for album in beatles.albums.order_by('sort_order').distinct('name')]
+        self.assertEqual(['Please Please Me', 'With The Beatles', 'Abbey Road'], albums)
 
     def test_parental_key_checks_clusterable_model(self):
         from django.core import checks


### PR DESCRIPTION
Fixes #29 

This PR adds the `distinct` method to the `FakeQuerySet` class. It mimics the behavior of django's `distinct` method - calls to `distinct` with a list of field names, are only allowed if the db connection vendor is postgresql. 