### PR TITLE
Add none method to FakeQuerySet

### DIFF
--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -380,7 +380,7 @@ class FakeQuerySet(object):
         new.tuple_fields = self.tuple_fields
         new.iterable_class = self.iterable_class
         return new
-    
+
     def resolve_q_object(self, q_object):
         connector = q_object.connector
         filters = []
@@ -405,14 +405,14 @@ class FakeQuerySet(object):
             else:
                 key_clauses, val = child
                 filters.append(_build_test_function_from_filter(self.model, key_clauses.split('__'), val))
-        
+
         return test(filters)
 
     def _get_filters(self, *args, **kwargs):
         # a list of test functions; objects must pass all tests to be included
         # in the filtered list
         filters = []
-        
+
         for q_object in args:
             filters.append(self.resolve_q_object(q_object))
 
@@ -526,6 +526,12 @@ class FakeQuerySet(object):
                 seen_keys.add(key)
                 unique_results.append(result)
         return self.get_clone(results=unique_results)
+
+    def none(self):
+        """
+        Return an empty QuerySet.
+        """
+        return self.get_clone(results=[])
 
     # a standard QuerySet will store the results in _result_cache on running the query;
     # this is effectively the same as self.results on a FakeQuerySet, and so we'll make

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -968,6 +968,35 @@ class ClusterTest(TestCase):
         albums = [album.name for album in beatles.albums.order_by('sort_order').distinct('name')]
         self.assertEqual(['Please Please Me', 'With The Beatles', 'Abbey Road'], albums)
 
+    def test_none(self):
+        beatles = Band(
+            name="The Beatles",
+            albums=[
+                Album(name="Please Please Me", sort_order=1),
+                Album(name="With The Beatles", sort_order=2),
+                Album(name="Abbey Road", sort_order=3),
+            ],
+        )
+
+        # none() should return an empty queryset
+        self.assertEqual([], list(beatles.albums.none()))
+        self.assertEqual(0, beatles.albums.none().count())
+
+    def test_none_is_chainable(self):
+        beatles = Band(
+            name="The Beatles",
+            albums=[
+                Album(name="Please Please Me", sort_order=1),
+                Album(name="With The Beatles", sort_order=2),
+            ],
+        )
+
+        # Chaining operations after none() should still return empty results
+        self.assertEqual(
+            [], list(beatles.albums.none().filter(name="Please Please Me"))
+        )
+        self.assertEqual([], list(beatles.albums.none().order_by("name")))
+
     def test_parental_key_checks_clusterable_model(self):
         from django.core import checks
         from django.db import models


### PR DESCRIPTION
This PR implements the `none()` method on `FakeQuerySet` to match Django's QuerySet API.

## Motivation

Django's QuerySet [has a `none()` method](https://docs.djangoproject.com/en/5.2/ref/models/querysets/#none) that returns an empty queryset. This is useful for:

- Conditional query building where you want to explicitly return nothing
- Testing code that uses `.none()`
- API completeness with Django's QuerySet interface

Currently, `FakeQuerySet` doesn't implement this method, which can cause issues when testing code that uses it.

---

Django implementation: <https://github.com/django/django/blob/2b0f24e6/django/db/models/query.py#L1604>