### PR TITLE
Preliminary Django 6.1 support

### DIFF
--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -451,7 +451,7 @@ def create_deferring_forward_many_to_many_manager(rel, original_manager_cls):
             """
             self.set([])
 
-        def set(self, objs, bulk=True, clear=False):
+        def set_base(self, objs, bulk=True, clear=False, through_defaults=None, raw=False):
             # cast objs to a list so that:
             # 1) we can call len() on it (which we can't do on, say, a queryset)
             # 2) if we need to sort it, we can do so without mutating the original
@@ -471,6 +471,9 @@ def create_deferring_forward_many_to_many_manager(rel, original_manager_cls):
                 sort_by_fields(objs, rel_model._meta.ordering)
 
             cluster_related_objects[relation_name] = objs
+
+        def set(self, objs, *, clear=False, through_defaults=None):
+            self.set_base(objs, clear=clear, through_defaults=through_defaults)
 
         def remove(self, *items_to_remove):
             """

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -556,3 +556,4 @@ class FakeQuerySet(object):
         return len(self.results)
 
     ordered = True  # results are returned in a consistent order
+    totally_ordered = True


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes compatibility issues with current `main` branch of Django (6.1).

### Description

<!-- Please describe the problem you're fixing. -->

- Added `totally_ordered` attribute to `FakeQuerySet`. This was introduced in django/django@08b4dfc. Wagtail's tests fail without this attribute.
- Add `set_base()` hook to `DeferringManyRelatedManager`. This was introduced in a series of commits: https://github.com/django/django/commit/c3b6c2969171d8867308406bb03d60f86a422904, https://github.com/django/django/commit/6fc2406fc534f97f245b8267703ab598a020fee5, https://github.com/django/django/commit/12d574407c466c7929e455cfcfef4c0ff564e465, and https://github.com/django/django/commit/4702b36120ea4c736d3f6b5595496f96e0021e46.
  - Without this, loading fixtures will not work.
  - See https://code.djangoproject.com/ticket/27380 for more details.
  - I also added the `through_defaults` argument to `set()` to match Django. This was added in https://github.com/django/django/commit/769355c76531749d0bc0abad279402e361eaec4e, which was committed well after 2ac71a2f9070e19585307b7b4987c9deee1eb7a4.
  - I didn't really implement the functionality for these. Would be nice to, but for now this is just a shim to prevent modelcluster from breaking entirely.


### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None