### PR TITLE
Support per-model FakeQuerySet class customisation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+~~~~~~~~~~
+* Add decorator-based registration for exposing custom QuerySet helper methods on model-specific FakeQuerySet instances.
+* Allow `fakequeryset_compatible` to attach methods to generated FakeQuerySet classes under an alternative method name.
+
 6.5 (01.05.2026)
 ~~~~~~~~~~~~~~~~
 * Preliminary Django 6.1 support (Sage Abdullah)

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,54 @@ But what if you could? There are all sorts of scenarios where you might want to 
 For more examples, see the unit tests.
 
 
+Custom QuerySet helpers on in-memory relations
+----------------------------------------------
+
+Custom ``QuerySet`` helper methods can be made available on in-memory relation querysets
+by decorating methods with ``fakequeryset_compatible``:
+
+.. code-block:: python
+
+ from django.db import models
+ from modelcluster.queryset import fakequeryset_compatible
+
+ class BandMemberQuerySet(models.QuerySet):
+     @fakequeryset_compatible
+     def named_paul(self):
+         return self.filter(name__contains="Paul")
+
+    # Database implementation
+     def with_name_uppercase(self):
+         return self.extra(select={"name_upper": "UPPER(name)"})
+
+    @fakequeryset_compatible(as_name="with_name_uppercase")
+    def with_name_uppercase_fake(self):
+        # No-op version specifically for FakeBandMemberQuerySet
+        return self
+
+ class BandMember(models.Model):
+     objects = BandMemberQuerySet.as_manager()
+     band = ParentalKey("Band", related_name="members", on_delete=models.CASCADE)
+     name = models.CharField(max_length=255)
+
+ >>> beatles = Band(name="The Beatles")
+ >>> beatles.members = [BandMember(name="John Lennon"), BandMember(name="Paul McCartney")]
+ >>> [member.name for member in beatles.members.named_paul()]
+ ['Paul McCartney']
+
+``as_name=...`` allows you to keep the original database-only method while attaching a
+separate in-memory implementation to the generated FakeQuerySet under that method name.
+
+Important: ``fakequeryset_compatible`` methods are discovered from the queryset class
+used by the model's default manager (``Model._default_manager``), including its queryset
+base classes. Decorating methods on unrelated queryset classes or non-default managers
+will not make them available on that model's generated FakeQuerySet.
+
+When you need to construct model-aware in-memory querysets directly, use
+``FakeQuerySet.from_instances(...)`` or ``get_fake_queryset_for_model(...)`` from
+``modelcluster.queryset``.
+
+
 Many-to-many relations
 ----------------------
 

--- a/modelcluster/contrib/taggit.py
+++ b/modelcluster/contrib/taggit.py
@@ -5,7 +5,7 @@ from taggit import VERSION as TAGGIT_VERSION
 from taggit.managers import TaggableManager, _TaggableManager
 from taggit.utils import require_instance_manager
 
-from modelcluster.queryset import FakeQuerySet
+from modelcluster.queryset import get_fake_queryset_for_model
 
 
 if TAGGIT_VERSION < (0, 20, 0):
@@ -35,7 +35,7 @@ class _ClusterTaggableManager(_TaggableManager):
             # we want to return those uncommitted changes. This shouldn't
             # require a request to the database.
             if tagged_item_manager.is_deferring:
-                return FakeQuerySet(
+                return get_fake_queryset_for_model(
                     self.through.tag_model(),
                     [tagged_item.tag for tagged_item in tagged_item_manager.all()],
                 )
@@ -75,7 +75,7 @@ class _ClusterTaggableManager(_TaggableManager):
             # To handle this case we return an empty tag list since there won't
             # be any existing tags in the database for an unsaved instance.
             elif self.instance.pk is None:
-                return FakeQuerySet(self.through.tag_model(), [])
+                return get_fake_queryset_for_model(self.through.tag_model(), [])
 
         # If we've reached this point then either this manager isn't associated
         # with a specific model, which probably means it's being invoked within

--- a/modelcluster/fields.py
+++ b/modelcluster/fields.py
@@ -15,7 +15,7 @@ from django.db.models.fields.related import (
 
 from modelcluster.utils import sort_by_fields
 
-from modelcluster.queryset import FakeQuerySet
+from modelcluster.queryset import get_fake_queryset_for_model
 
 
 def create_deferring_foreign_related_manager(related, original_manager_cls):
@@ -78,7 +78,7 @@ def create_deferring_foreign_related_manager(related, original_manager_cls):
                 else:
                     return self.get_live_queryset()
 
-            return FakeQuerySet(related.related_model, results)
+            return get_fake_queryset_for_model(related.related_model, results)
 
         def _apply_rel_filters(self, queryset):
             # Implemented as empty for compatibility sake
@@ -361,7 +361,7 @@ def create_deferring_forward_many_to_many_manager(rel, original_manager_cls):
                     # so bypass it and return an empty queryset
                     return rel_model.objects.none()
 
-            return FakeQuerySet(rel_model, results)
+            return get_fake_queryset_for_model(rel_model, results)
 
         def get_prefetch_querysets(self, instances, querysets=None):
             # Derived from Django's ManyRelatedManager.get_prefetch_queryset.

--- a/modelcluster/queryset.py
+++ b/modelcluster/queryset.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import inspect
+import logging
 import re
 
 from django.core.exceptions import FieldDoesNotExist
@@ -313,6 +315,108 @@ FILTER_EXPRESSION_TOKENS = {
 }
 
 
+FAKE_QUERYSET_SAFE_METHOD_ATTR = "_modelcluster_fake_queryset_safe_method"
+FAKE_QUERYSET_SAFE_METHOD_NAME_ATTR = "_modelcluster_fake_queryset_safe_name"
+# Preferred aliases for the decorator metadata attributes.
+FAKEQUERYSET_COMPATIBLE_METHOD_ATTR = FAKE_QUERYSET_SAFE_METHOD_ATTR
+FAKEQUERYSET_COMPATIBLE_METHOD_NAME_ATTR = FAKE_QUERYSET_SAFE_METHOD_NAME_ATTR
+_registered_fake_queryset_classes = {}
+_generated_fake_queryset_classes = {}
+logger = logging.getLogger(__name__)
+
+
+class QuerySetMethodOrAttributeUnavailableError(AttributeError):
+    pass
+
+
+def fakequeryset_compatible(method=None, *, as_name=None):
+    """
+    Mark a QuerySet helper method as safe to run against FakeQuerySet instances.
+    """
+
+    def _decorator(decorated_method):
+        fake_method_name = as_name or decorated_method.__name__
+        existing_attr = inspect.getattr_static(FakeQuerySet, fake_method_name, None)
+        if callable(existing_attr):
+            logger.warning(
+                "fakequeryset_compatible registered method name '%s' conflicts with FakeQuerySet.%s. "
+                "Overrides are not supported, so the custom method is ignored",
+                fake_method_name,
+                fake_method_name,
+            )
+            return decorated_method
+        setattr(decorated_method, FAKE_QUERYSET_SAFE_METHOD_ATTR, True)
+        setattr(
+            decorated_method,
+            FAKE_QUERYSET_SAFE_METHOD_NAME_ATTR,
+            fake_method_name,
+        )
+        return decorated_method
+
+    if method is None:
+        return _decorator
+
+    return _decorator(method)
+
+
+# Backwards-compatible alias for older integrations.
+fake_queryset_safe = fakequeryset_compatible
+
+
+def register_fake_queryset(model):
+    """
+    Register a custom FakeQuerySet subclass for a model.
+    """
+
+    def _decorator(fake_queryset_class):
+        _registered_fake_queryset_classes[model] = fake_queryset_class
+        return fake_queryset_class
+
+    return _decorator
+
+
+def _get_safe_fake_queryset_methods(queryset_class):
+    methods = {}
+    for cls in reversed(queryset_class.__mro__):
+        for name, method in cls.__dict__.items():
+            if getattr(method, FAKE_QUERYSET_SAFE_METHOD_ATTR, False):
+                fake_method_name = getattr(
+                    method, FAKE_QUERYSET_SAFE_METHOD_NAME_ATTR, name
+                )
+                methods[fake_method_name] = method
+    return methods
+
+
+def _get_queryset_class_for_model(model):
+    manager = model._default_manager
+    return getattr(manager, "_queryset_class", manager.get_queryset().__class__)
+
+
+def get_fake_queryset_class_for_model(model):
+    registered_class = _registered_fake_queryset_classes.get(model)
+    if registered_class is not None:
+        return registered_class
+
+    generated_class = _generated_fake_queryset_classes.get(model)
+    if generated_class is not None:
+        return generated_class
+
+    queryset_class = _get_queryset_class_for_model(model)
+    safe_methods = _get_safe_fake_queryset_methods(queryset_class)
+    if not safe_methods:
+        return FakeQuerySet
+
+    generated_class = type(
+        "Fake%sQuerySet" % model.__name__, (FakeQuerySet,), safe_methods
+    )
+    _generated_fake_queryset_classes[model] = generated_class
+    return generated_class
+
+
+def get_fake_queryset_for_model(model, results):
+    return get_fake_queryset_class_for_model(model)(model, results)
+
+
 def _build_test_function_from_filter(model, key_clauses, val):
     # Translate a filter kwarg rule (e.g. foo__bar__exact=123) into a function which can
     # take a model instance and return a boolean indicating whether it passes the rule
@@ -396,6 +500,21 @@ class FlatValuesListIterable(FakeQuerySetIterable):
 
 
 class FakeQuerySet(object):
+    @classmethod
+    def from_instances(cls, instances, model=None):
+        results = list(instances)
+        if model is None:
+            if not results:
+                raise ValueError("Cannot infer model from an empty instance list.")
+            model = results[0].__class__
+        elif any(not isinstance(instance, model) for instance in results):
+            raise TypeError("All instances must be of type %s." % model.__name__)
+
+        if cls is FakeQuerySet:
+            return get_fake_queryset_for_model(model, results)
+
+        return cls(model, results)
+
     def __init__(self, model, results):
         self.model = model
         self.results = results
@@ -407,7 +526,7 @@ class FakeQuerySet(object):
         return self
 
     def get_clone(self, results=None):
-        new = FakeQuerySet(self.model, results if results is not None else self.results)
+        new = type(self)(self.model, results if results is not None else self.results)
         new.dict_fields = self.dict_fields
         new.tuple_fields = self.tuple_fields
         new.iterable_class = self.iterable_class
@@ -606,6 +725,23 @@ class FakeQuerySet(object):
 
     def __len__(self):
         return len(self.results)
+
+    def __getattr__(self, method_name):
+        if method_name.startswith("__") and method_name.endswith("__"):
+            raise AttributeError(method_name)
+
+        raise QuerySetMethodOrAttributeUnavailableError(
+            "To support features like 'draft preview' without saving changes to "
+            "the database, your model data is being represented in-memory by a "
+            "%s instance. This class only implements a subset of the Django QuerySet "
+            "API, and only has access to explicitly registered custom queryset methods. "
+            "If you would like for '%s' to be available in this context, use the "
+            "modelcluster.queryset.fakequeryset_compatible decorator to mark the "
+            "method on the QuerySet class used by your model's default manager. "
+            "Consider using the 'as_name' option if you would prefer to register a "
+            "separate implementation for use in this context."
+            % (self.__class__.__name__, method_name)
+        )
 
     ordered = True  # results are returned in a consistent order
     totally_ordered = True

--- a/tests/models.py
+++ b/tests/models.py
@@ -8,6 +8,7 @@ from taggit.models import TaggedItemBase
 
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
 from modelcluster.models import ClusterableModel
+from modelcluster.queryset import fakequeryset_compatible
 
 
 class Band(ClusterableModel):
@@ -17,7 +18,29 @@ class Band(ClusterableModel):
         return self.name
 
 
+class BandMemberQuerySet(models.QuerySet):
+    @fakequeryset_compatible
+    def named_paul(self):
+        return self.filter(name__contains="Paul")
+
+    @fakequeryset_compatible
+    def names_starting_with(self, prefix):
+        return self.filter(name__startswith=prefix)
+
+    @fakequeryset_compatible(as_name="with_name_uppercase")
+    def with_name_uppercase_in_memory(self):
+        return self
+
+    def with_name_uppercase(self):
+        return self.extra(select={"name_upper": "UPPER(name)"})
+
+    def db_only_helper(self):
+        return self.extra(select={"name_lower": "LOWER(name)"})
+
+
 class BandMember(models.Model):
+    objects = BandMemberQuerySet.as_manager()
+
     band = ParentalKey("Band", related_name="members", on_delete=models.CASCADE)
     name = models.CharField(max_length=255)
     favourite_restaurant = models.ForeignKey(

--- a/tests/tests/test_cluster.py
+++ b/tests/tests/test_cluster.py
@@ -6,6 +6,7 @@ import itertools
 from django.test import TestCase
 from django.db import IntegrityError
 from django.db.models import Prefetch, Q
+from django.db import models
 
 from modelcluster.models import get_all_child_relations
 from modelcluster.queryset import FakeQuerySet
@@ -1422,7 +1423,6 @@ class ClusterTest(TestCase):
 
     def test_parental_key_checks_clusterable_model(self):
         from django.core import checks
-        from django.db import models
         from modelcluster.fields import ParentalKey
 
         class Instrument(models.Model):
@@ -1453,7 +1453,6 @@ class ClusterTest(TestCase):
 
     def test_parental_key_checks_related_name_is_not_plus(self):
         from django.core import checks
-        from django.db import models
         from modelcluster.fields import ParentalKey
 
         class Instrument(models.Model):
@@ -1481,7 +1480,6 @@ class ClusterTest(TestCase):
 
     def test_parental_key_checks_target_is_resolved_as_class(self):
         from django.core import checks
-        from django.db import models
         from modelcluster.fields import ParentalKey
 
         class Instrument(models.Model):

--- a/tests/tests/test_fakequeryset_customisation.py
+++ b/tests/tests/test_fakequeryset_customisation.py
@@ -1,0 +1,201 @@
+from __future__ import unicode_literals
+
+from django.db import models
+from django.test import TestCase
+
+from modelcluster.queryset import (
+    FAKEQUERYSET_COMPATIBLE_METHOD_ATTR,
+    FakeQuerySet,
+    QuerySetMethodOrAttributeUnavailableError,
+    fakequeryset_compatible,
+    get_fake_queryset_for_model,
+)
+from tests.models import Band, BandMember
+
+
+class FakeQuerySetCustomisationTest(TestCase):
+    def test_decorated_queryset_helpers_available_on_fake_queryset(self):
+        beatles = Band(
+            name="The Beatles",
+            members=[
+                BandMember(name="John Lennon"),
+                BandMember(name="Paul McCartney"),
+                BandMember(name="Ringo Starr"),
+            ],
+        )
+
+        self.assertEqual(
+            ["Paul McCartney"], [member.name for member in beatles.members.named_paul()]
+        )
+        self.assertEqual(
+            ["Paul McCartney"],
+            [member.name for member in beatles.members.names_starting_with("Paul")],
+        )
+
+    def test_undecorated_queryset_helpers_not_available_on_fake_queryset(self):
+        beatles = Band(
+            name="The Beatles",
+            members=[BandMember(name="John Lennon"), BandMember(name="Paul McCartney")],
+        )
+
+        with self.assertRaisesMessage(
+            QuerySetMethodOrAttributeUnavailableError,
+            "only has access to explicitly registered custom queryset methods",
+        ):
+            beatles.members.db_only_helper()
+
+    def test_fakequeryset_factory_from_instances(self):
+        queryset = FakeQuerySet.from_instances(
+            [BandMember(name="John Lennon"), BandMember(name="Paul McCartney")]
+        )
+        self.assertIsNot(type(queryset), FakeQuerySet)
+        self.assertEqual(
+            ["Paul McCartney"], [member.name for member in queryset.named_paul()]
+        )
+
+        empty_queryset = FakeQuerySet.from_instances([], model=BandMember)
+        self.assertEqual([], list(empty_queryset.named_paul()))
+
+        self.assertRaises(ValueError, lambda: FakeQuerySet.from_instances([]))
+        self.assertRaises(
+            TypeError,
+            lambda: FakeQuerySet.from_instances(
+                [BandMember(name="Paul McCartney")], model=Band
+            ),
+        )
+
+    def test_get_fakequeryset_for_model_uses_decorated_helpers(self):
+        queryset = get_fake_queryset_for_model(
+            BandMember,
+            [BandMember(name="John Lennon"), BandMember(name="Paul McCartney")],
+        )
+
+        self.assertEqual(type(queryset).__name__, "FakeBandMemberQuerySet")
+        self.assertEqual(
+            ["Paul McCartney"], [member.name for member in queryset.named_paul()]
+        )
+
+    def test_fakequeryset_compatible_alias_can_replace_db_method_name(self):
+        beatles = Band(
+            name="The Beatles",
+            members=[BandMember(name="John Lennon"), BandMember(name="Paul McCartney")],
+        )
+
+        self.assertEqual(
+            ["John Lennon", "Paul McCartney"],
+            [member.name for member in beatles.members.with_name_uppercase()],
+        )
+
+    def test_fakequeryset_compatible_alias_conflict_is_ignored(self):
+        with self.assertLogs("modelcluster.queryset", level="WARNING") as captured_logs:
+
+            class ConflictingAliasQuerySet(models.QuerySet):
+                @fakequeryset_compatible(as_name="filter")
+                def fake_filter_alias(self):
+                    return self
+
+        self.assertEqual(
+            len(captured_logs.output),
+            1,
+        )
+        self.assertIn(
+            "fakequeryset_compatible registered method name 'filter' conflicts with FakeQuerySet.filter. Overrides are not supported, so the custom method is ignored",
+            captured_logs.output[0],
+        )
+        self.assertFalse(
+            getattr(
+                ConflictingAliasQuerySet.fake_filter_alias,
+                FAKEQUERYSET_COMPATIBLE_METHOD_ATTR,
+                False,
+            )
+        )
+
+    def test_fakequeryset_compatible_default_name_conflict_is_ignored(self):
+        with self.assertLogs("modelcluster.queryset", level="WARNING") as captured_logs:
+
+            class ConflictingMethodNameQuerySet(models.QuerySet):
+                @fakequeryset_compatible
+                def filter(self, *args, **kwargs):
+                    return self
+
+        self.assertEqual(
+            len(captured_logs.output),
+            1,
+        )
+        self.assertIn(
+            "fakequeryset_compatible registered method name 'filter' conflicts with FakeQuerySet.filter. Overrides are not supported, so the custom method is ignored",
+            captured_logs.output[0],
+        )
+        self.assertFalse(
+            getattr(
+                ConflictingMethodNameQuerySet.filter,
+                FAKEQUERYSET_COMPATIBLE_METHOD_ATTR,
+                False,
+            )
+        )
+
+    def test_fakequeryset_compatible_methods_are_inherited_from_queryset_bases(self):
+        class ThirdPartyPageQuerySet(models.QuerySet):
+            @fakequeryset_compatible
+            def third_party_helper(self):
+                return "third-party"
+
+        class EventPageQuerySet(ThirdPartyPageQuerySet):
+            pass
+
+        class EventPage(models.Model):
+            objects = EventPageQuerySet.as_manager()
+
+            class Meta:
+                abstract = True
+
+        fake_queryset = get_fake_queryset_for_model(EventPage, [])
+        self.assertEqual(fake_queryset.third_party_helper(), "third-party")
+
+    def test_fakequeryset_compatible_subclass_override_wins(self):
+        class ThirdPartyPageQuerySet(models.QuerySet):
+            @fakequeryset_compatible
+            def helper_source(self):
+                return "third-party"
+
+        class EventPageQuerySet(ThirdPartyPageQuerySet):
+            @fakequeryset_compatible
+            def helper_source(self):
+                return "project"
+
+        class EventPage(models.Model):
+            objects = EventPageQuerySet.as_manager()
+
+            class Meta:
+                abstract = True
+
+        fake_queryset = get_fake_queryset_for_model(EventPage, [])
+        self.assertEqual(fake_queryset.helper_source(), "project")
+
+    def test_model_inheritance_without_queryset_inheritance_does_not_copy_helpers(self):
+        class ThirdPartyPageQuerySet(models.QuerySet):
+            @fakequeryset_compatible
+            def third_party_helper(self):
+                return "third-party"
+
+        class Page(models.Model):
+            objects = ThirdPartyPageQuerySet.as_manager()
+
+            class Meta:
+                abstract = True
+
+        class EventPageQuerySet(models.QuerySet):
+            @fakequeryset_compatible
+            def event_helper(self):
+                return "event"
+
+        class EventPage(Page):
+            objects = EventPageQuerySet.as_manager()
+
+            class Meta:
+                abstract = True
+
+        fake_queryset = get_fake_queryset_for_model(EventPage, [])
+        self.assertEqual(fake_queryset.event_helper(), "event")
+        with self.assertRaises(QuerySetMethodOrAttributeUnavailableError):
+            fake_queryset.third_party_helper()


### PR DESCRIPTION
Implements #209 

## Description

Allows registering of methods on a models manager's default `QuerySet` as compatible with `FakeQuerySet` classes via a new `@fakequeryset_compatible` decorator - so that they become available in draft/preview/in-memory-only contexts.

When used, assembled in-memory classes take on the name `FakeModelNameQuerySet`, and have the decorated methods copied over to them. The methods will then be available to use on in-memory versions of those querysets, AND fake querysets returned by parent -> child relationship access.

The generated classes are cached to avoid repeat effort, and are true `FakeQuerySet` subclasses, so any in-project code that does `isinstance(queryset, FakeQuerySet)` will continue to work with these changes in place.

The decorator supports an `as_name` option, which allows developers to write alternative implementations of methods on querysets specifically for in-memory usage (where they live alongside the original implementation). This is useful in cases where developers want the 'regular' querysets to continue to use the ORM implementation, but are happy to add a pure-Python version for the in-memory representation case, where the options would be:

1. Return `self` to serve as a stub/no-op
2. Recreate what the ORM version does exactly
3. Implement a simplified / dumbed-down version of the ORM behaviour

Attempts to override methods that `FakeQuerySet` already implements will raise a clear warning, and the registered version of the method will be ignored.

## Additional changes

It's clear from issue reports that there is a lot of confusion when developers see a bare `AttributeError` when trying to use custom queryset methods in a draft/preview context without an explanation of why it's occurring. So, this PR introduces `QuerySetMethodOrAttributeUnavailableError` to better explain why it is happening, and also proposes a solution. It's an `AttributeError` subclass, so any existing projects attempting to catch/handle the original exception will still work.

## Design justifications

### Why not just force devs to define a custom FakeQuerySet class, and register that somehow?

While this might be beneficial from a clarity / typing perspective, it comes with complication and development overhead, e.g. 
- _Where should these classes live in the codebase?_
- _How do I ensure the queryset and fake implementations stay in-sync over time?_
- _I already have a nice class-inheritance tree for my querysets... do I need to replicate that with FakeQuerySet subclasses too? What naming patterns would make sense for that?_

The simple decorator approach solves all this by:
- Keeping everything together on existing QuerySet definitions. 
- The decorator name is clear in it's intention, and devs can use simple comment / docstring additions to reference any dual implementation pairs
- Inheritance works as-expected alongside queryset inheritance.. no separate trees to manage.

Plus, `django-modelcluster` is really a 'tool choice' of Wagtail. I think forcing a full understanding of FakeQuerySet on developers and pushing them toward class replication / duplication is a bad idea generally - This isn't a common enough problem in projects to make devs completely rethink their approach to code definition. Being able to decorate existing code in-place is a low-footprint 'Get out of jail free card' - just for when you need it.

### Why log a warning when method name clashes are detected instead of raising a hard exception?

This could add unnecessary friction to the upgrade process should the `FakeQuerySet` API be updated to support more of Django's QuerySet API in future. Release management is complicated enough without having to worry about breaking live-running projects that are currently using their own, native implementation.

## Exciting thoughts

- The decorator could be used to experiment in-project with implementations of QuerySet methods that aren't yet supported by FakeQuerySet - which could lower the barrier to sharing and eventual contribution.
- Third-party apps that use django-modelcluster (e.g. Wagtail) can opt to register methods on their own custom queryset classes, helping to reduce ocurrances of `QuerySetMethodOrAttributeUnavailableError` in the first-place - all without polluting FakeQuerySets's generic API.

## AI usage

Like many devs, I use AI as part of my everyday development process - but, never as a shortcut to thinking things through. In this case, OpenAI's Codex 5.3 model was used (via Cursor) for scaffolding the changes based on the issue description I put together. I then iterated on that implementation to add the method-name conflict handling and other tweaks. The idea itself, decisions on naming/messaging, inheritance-scenario tests etc were all my own - as is this PR description.
